### PR TITLE
Dark mode

### DIFF
--- a/src/components/v2/ThemeToggle.tsx
+++ b/src/components/v2/ThemeToggle.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useTheme } from './useTheme';
+
+export default function ThemeToggle() {
+  const { theme, toggle } = useTheme();
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="theme-toggle"
+      aria-label={`Switch to ${isDark ? 'light' : 'dark'} mode`}
+      title={`Switch to ${isDark ? 'light' : 'dark'} mode`}
+    >
+      {isDark ? (
+        // sun
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+        </svg>
+      ) : (
+        // moon
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/src/components/v2/V2Nav.tsx
+++ b/src/components/v2/V2Nav.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import ThemeToggle from './ThemeToggle';
 import { usePathname } from 'next/navigation';
 
 const NAV_LINKS = [
@@ -63,6 +64,7 @@ export default function V2Nav() {
         </li>
       </ul>
       <div className="nav-right">
+        <ThemeToggle />
         <Link href="/testnet#resources" className="btn btn-primary">
           Get started <span className="arrow">→</span>
         </Link>

--- a/src/components/v2/useTheme.ts
+++ b/src/components/v2/useTheme.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'bqv2-theme';
+export type Theme = 'light' | 'dark';
+
+/**
+ * Reads the user's theme preference from localStorage (with fallback
+ * to prefers-color-scheme) and keeps every .bqv2 root on the page in
+ * sync via the data-theme attribute. Every change persists.
+ */
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>('light');
+
+  // Initial read after mount — server renders light, then we sync.
+  useEffect(() => {
+    let next: Theme = 'light';
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY) as Theme | null;
+      if (stored === 'light' || stored === 'dark') {
+        next = stored;
+      } else if (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        next = 'dark';
+      }
+    } catch {
+      /* ignore — fall back to light */
+    }
+    setThemeState(next);
+    applyTheme(next);
+  }, []);
+
+  const setTheme = (next: Theme) => {
+    setThemeState(next);
+    applyTheme(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const toggle = () => setTheme(theme === 'light' ? 'dark' : 'light');
+
+  return { theme, setTheme, toggle };
+}
+
+function applyTheme(theme: Theme) {
+  if (typeof document === 'undefined') return;
+  document.querySelectorAll('.bqv2').forEach((el) => {
+    el.setAttribute('data-theme', theme);
+  });
+}

--- a/src/components/v2/v2.css
+++ b/src/components/v2/v2.css
@@ -67,6 +67,20 @@
   color-scheme: dark;
 }
 
+/* In dark mode, prose headlines go near-white instead of brand cyan
+   so the brand blue lands on accent strokes (eyebrows, ticks) and
+   the stat numbers (21M / 1 min / 8 MB / FIPS 204) — they pop more
+   when the headlines aren't competing for the same color. */
+.bqv2[data-theme="dark"] h1,
+.bqv2[data-theme="dark"] h2,
+.bqv2[data-theme="dark"] h3,
+.bqv2[data-theme="dark"] .statement .big,
+.bqv2[data-theme="dark"] .hero .display .serif,
+.bqv2[data-theme="dark"] .statement .big .serif,
+.bqv2[data-theme="dark"] .ref-card h3 {
+  color: var(--ink);
+}
+
 .bqv2 * { box-sizing: border-box; margin: 0; padding: 0; }
 .bqv2 img, .bqv2 svg { display: block; }
 .bqv2 a { color: inherit; text-decoration: none; }

--- a/src/components/v2/v2.css
+++ b/src/components/v2/v2.css
@@ -251,6 +251,24 @@
 .bqv2 .nav-right { display: flex; align-items: center; gap: 18px; }
 .bqv2 .nav-toggle { display: none; background: none; border: none; cursor: pointer; color: var(--ink); }
 
+/* theme toggle — circular icon button beside Get started */
+.bqv2 .theme-toggle {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 38px; height: 38px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--ink-2);
+  cursor: pointer;
+  transition: color .15s, border-color .15s, background .15s, transform .15s;
+}
+.bqv2 .theme-toggle:hover {
+  color: var(--ink);
+  border-color: var(--ink-3);
+  background: color-mix(in srgb, var(--ink) 4%, transparent);
+}
+.bqv2 .theme-toggle:active { transform: scale(0.94); }
+
 /* ============================================================
    HERO
    ============================================================ */


### PR DESCRIPTION
## Summary

Wires up a dark mode toggle on top of the dark theme tokens already defined in `v2.css` from the original design.

## Commits

- **`a521303` Add dark mode toggle** — `useTheme` hook reads `localStorage`, falls back to `prefers-color-scheme`, syncs every `.bqv2` root via `data-theme`. `ThemeToggle` component (circular sun/moon icon button) lives in `nav-right` beside Get started. Choice persists.
- **`a9121ff` Dark mode: white headlines instead of cyan** — `h1`/`h2`/`h3`/`.statement .big`/the italic flourishes go near-white in dark mode only. Brand cyan stays on eyebrows, stat numbers, ticks, buttons, hover states.

## Caveats

- **Brief FOUC** — SSR renders light; hydration switches to dark if `prefers-color-scheme: dark` or stored choice says dark. Fix is an inline `<head>` script (~5 lines) — held off here since "test that out" was the framing.
- **Only walked `/` visually** — `/protocol`, `/testnet`, `/faq` share the same `.bqv2` wrapper + token system so they should adapt, but worth a real-browser click-through on the preview.

## Test plan
- [ ] Visit `/` in the Vercel preview, toggle light ↔ dark, confirm both look intentional
- [ ] Confirm choice persists across reloads
- [ ] Walk `/protocol`, `/testnet`, `/faq` in dark mode — flag anything that reads as misformatted
- [ ] Test on iOS / Android / Windows browsers (toggle button accessible from mobile menu? confirm)