### PR TITLE
Theme: follow OS-level light/dark changes

### DIFF
--- a/src/components/v2/useTheme.ts
+++ b/src/components/v2/useTheme.ts
@@ -30,6 +30,25 @@ export function useTheme() {
     applyTheme(next);
   }, []);
 
+  // Follow OS-level dark/light changes mid-session — but only when
+  // the user hasn't made an explicit toggle choice. Their click wins.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = (e: MediaQueryListEvent) => {
+      try {
+        if (localStorage.getItem(STORAGE_KEY)) return; // explicit choice locks the theme
+      } catch {
+        /* ignore */
+      }
+      const next: Theme = e.matches ? 'dark' : 'light';
+      setThemeState(next);
+      applyTheme(next);
+    };
+    mq.addEventListener('change', onChange);
+    return () => mq.removeEventListener('change', onChange);
+  }, []);
+
   const setTheme = (next: Theme) => {
     setThemeState(next);
     applyTheme(next);


### PR DESCRIPTION
## Summary

Adds a `matchMedia` listener so the site reacts when the OS flips light↔dark mid-session (e.g. macOS auto-switching at sunset, or the user manually flipping their system theme).

The existing rule still holds: **if the user has clicked the toggle even once, their explicit choice wins** — `localStorage` lock-in. Only auto-tracks for users who've never toggled.

## Behavior summary after this PR

| User state | OS flips to dark | OS flips to light |
|---|---|---|
| Never clicked toggle | Site → dark | Site → light |
| Clicked toggle once (light) | Stays light | Stays light |
| Clicked toggle once (dark) | Stays dark | Stays dark |

## Caveats

Subscribes once and cleans up on unmount — `matchMedia.addEventListener('change', …)` is supported on all modern browsers (Safari 14+, Firefox/Chrome long ago).

## Test plan
- [ ] Set OS to light, never click toggle, then flip OS to dark — site should follow
- [ ] Click toggle to set explicit choice, then flip OS — site should NOT follow
- [ ] Clear localStorage, refresh — site should match current OS preference