### PR TITLE
Meta: 'Bitcoin, secured for the quantum era' tagline

### DIFF
--- a/src/app/faq/layout.tsx
+++ b/src/app/faq/layout.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next';
 
 const FAQ_DESC =
-  'Common questions about Bitcoin Quantum (BTQ) — quantum-resistant cryptography, ' +
+  'Common questions about Bitcoin Quantum (BTQ): quantum-resistant cryptography, ' +
   'BTQ vs Bitcoin differences, mining, security model, and the 21 million supply cap.';
 
 export const metadata: Metadata = {
@@ -13,13 +13,13 @@ export const metadata: Metadata = {
   ],
   alternates: { canonical: '/faq' },
   openGraph: {
-    title: 'FAQ — Bitcoin Quantum',
+    title: 'FAQ | Bitcoin Quantum',
     description: FAQ_DESC,
     url: '/faq',
     type: 'article',
   },
   twitter: {
-    title: 'FAQ — Bitcoin Quantum',
+    title: 'FAQ | Bitcoin Quantum',
     description: FAQ_DESC,
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,14 +23,14 @@ const dmSans = DM_Sans({
 });
 
 const DESCRIPTION =
-  "Bitcoin Quantum (BTQ) is Bitcoin rebuilt on NIST-standardized post-quantum cryptography. " +
-  "The same 21 million coins and the same proof-of-work network, signed with CRYSTALS-Dilithium.";
+  'Bitcoin rebuilt on post-quantum cryptography. ' +
+  'Same 21 million coins, same proof-of-work network.';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://bitcoinquantum.com'),
   title: {
-    template: '%s — Bitcoin Quantum',
-    default: 'Bitcoin Quantum — Bitcoin for the post-quantum era',
+    template: '%s | Bitcoin Quantum',
+    default: 'Bitcoin, secured for the quantum era.',
   },
   description: DESCRIPTION,
   keywords: [
@@ -43,7 +43,7 @@ export const metadata: Metadata = {
   publisher: "Bitcoin Quantum",
   formatDetection: { email: false, address: false, telephone: false },
   openGraph: {
-    title: 'Bitcoin Quantum — Bitcoin for the post-quantum era',
+    title: 'Bitcoin, secured for the quantum era.',
     description: DESCRIPTION,
     url: 'https://bitcoinquantum.com',
     siteName: 'Bitcoin Quantum',
@@ -52,7 +52,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Bitcoin Quantum — Bitcoin for the post-quantum era',
+    title: 'Bitcoin, secured for the quantum era.',
     description: DESCRIPTION,
     creator: '@bitcoinquantum',
     site: '@bitcoinquantum',

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -4,7 +4,7 @@ export default function manifest(): MetadataRoute.Manifest {
   return {
     name: 'Bitcoin Quantum',
     short_name: 'BTQ',
-    description: 'Bitcoin for the post-quantum era — NIST-standardized quantum-safe cryptography.',
+    description: 'Bitcoin for the post-quantum era. NIST-standardized quantum-safe cryptography.',
     start_url: '/',
     display: 'standalone',
     background_color: '#F1F2F4',

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -13,7 +13,7 @@ import { join } from 'node:path';
  * SVG off disk and embed it instead of re-typing a wordmark.
  */
 export const runtime = 'nodejs';
-export const alt = 'Bitcoin Quantum — Bitcoin for the post-quantum era';
+export const alt = 'Bitcoin, secured for the quantum era.';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,25 +3,30 @@ import { v2FontClassName } from '@/components/v2/fonts';
 import V2Page from './V2Page';
 import '@/components/v2/v2.css';
 
-// Home keeps the long brand title (root layout's title template only
-// fires when a page sets a string title; .absolute opts out of the template).
+// Home uses the tagline as its absolute title (root layout's title
+// template only fires when a page sets a string title; .absolute opts
+// out of the template). `og:site_name` from layout.tsx still shows
+// "Bitcoin Quantum" above this in link previews.
 const HOME_DESC =
-  'The same 21 million coins and the same proof-of-work network you trust — ' +
-  'rebuilt on NIST-standardized post-quantum cryptography.';
+  'Bitcoin rebuilt on post-quantum cryptography. ' +
+  'Same 21 million coins, same proof-of-work network.';
 
 export const metadata: Metadata = {
-  title: { absolute: 'Bitcoin Quantum — Bitcoin for the post-quantum era' },
+  // Browser tab gets the brand explicitly (template doesn't apply to
+  // .absolute titles). OG/Twitter titles below keep the clean tagline
+  // since og:site_name carries "Bitcoin Quantum" in link previews.
+  title: { absolute: 'Bitcoin, secured for the quantum era | Bitcoin Quantum' },
   description: HOME_DESC,
   alternates: { canonical: '/' },
   openGraph: {
-    title: 'Bitcoin Quantum — Bitcoin for the post-quantum era',
+    title: 'Bitcoin, secured for the quantum era.',
     description: HOME_DESC,
     url: '/',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Bitcoin Quantum — Bitcoin for the post-quantum era',
+    title: 'Bitcoin, secured for the quantum era.',
     description: HOME_DESC,
   },
 };

--- a/src/app/protocol/page.tsx
+++ b/src/app/protocol/page.tsx
@@ -15,14 +15,14 @@ export const metadata: Metadata = {
   description: PROTOCOL_DESC,
   alternates: { canonical: '/protocol' },
   openGraph: {
-    title: 'Protocol — Bitcoin Quantum',
+    title: 'Protocol | Bitcoin Quantum',
     description: PROTOCOL_DESC,
     url: '/protocol',
     type: 'article',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Protocol — Bitcoin Quantum',
+    title: 'Protocol | Bitcoin Quantum',
     description: PROTOCOL_DESC,
   },
 };

--- a/src/app/testnet/page.tsx
+++ b/src/app/testnet/page.tsx
@@ -15,14 +15,14 @@ export const metadata: Metadata = {
   description: TESTNET_DESC,
   alternates: { canonical: '/testnet' },
   openGraph: {
-    title: 'Testnet — Bitcoin Quantum',
+    title: 'Testnet | Bitcoin Quantum',
     description: TESTNET_DESC,
     url: '/testnet',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Testnet — Bitcoin Quantum',
+    title: 'Testnet | Bitcoin Quantum',
     description: TESTNET_DESC,
   },
 };


### PR DESCRIPTION
## Summary

- New home-page tagline for link previews: **"Bitcoin, secured for the quantum era."** — reinforces the OG card headline instead of duplicating it with a competing phrase.
- Tighter home description: *"Bitcoin rebuilt on post-quantum cryptography. Same 21 million coins, same proof-of-work network."*
- Dropped em-dashes from all metadata strings across `/`, `/protocol`, `/testnet`, `/faq` titles + descriptions, the manifest, and the OG image alt. (Body-copy em-dashes left intact.)
- Browser-tab title for the home page keeps the brand explicitly (`%s | Bitcoin Quantum`) since the `.absolute` title opts out of the template.

After deploy: ping `@WebpageBot` on Telegram to bust its cache so the new preview shows and `og:site_name` lands as "Bitcoin Quantum" instead of the domain-derived "Bitcoinquantum".