### PR TITLE
docs: refresh README/CLAUDE for v2 architecture, ignore internal content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,13 @@ yarn-error.log*
 # vercel
 .vercel
 
+# in-process source material (whitepaper drafts, content notes)
+/docs/whitepaper/
+
+# internal content/voice/strategy + Typefully integration — local-only,
+# not for the public repo
+/docs/content/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Marketing site for **Bitcoin Quantum (BTQ)**, a quantum-resistant fork of Bitcoin (post-quantum signatures via CRYSTALS-Dilithium / ML-DSA / NIST FIPS 204; same 21M supply and proof-of-work). Pure Next.js 15 App Router site — no backend, no database, no API routes. Content is hardcoded in page components.
+
+## Commands
+
+```bash
+npm run dev      # dev server with Turbopack (http://localhost:3000)
+npm run build    # production build with Turbopack
+npm start        # serve the production build
+npm run lint     # eslint (flat config, next/core-web-vitals + next/typescript)
+```
+
+There is no test suite. There is no separate typecheck script — type errors surface during `build`.
+
+## Architecture
+
+### "v2" is the live site; `globals.css` is legacy
+
+The codebase carries two parallel design systems. **Everything currently routed uses the v2 system.** Don't be misled by the older one:
+
+- **`src/components/v2/v2.css`** — the active design system. All selectors are scoped under `.bqv2` so they can't leak. This is what every live page renders inside.
+- **`src/app/globals.css`** — the older dark/cyan theme (`@theme inline`, `.gradient-text`, grid background). Imported by the root layout but largely vestigial. Don't build new UI against it.
+
+The README.md is **stale** — it documents retired `/introduction` and `/resources` pages and the old design. Trust the code over the README. Retired routes are 301-redirected in `next.config.ts` (`/introduction → /`, `/resources → /testnet`, `/v2 → /`).
+
+### v2 design-system primitives
+
+Any new page must opt into the v2 system the same way existing pages do:
+
+1. Wrap the page in an element with **both** the `bqv2` class and `className={v2FontClassName}` (from `src/components/v2/fonts.ts`), and `import '@/components/v2/v2.css'`.
+2. `v2FontClassName` wires up the four `next/font/google` families as CSS variables: Archivo (`--display`), Newsreader (`--serif`), Hanken Grotesk (`--sans`), IBM Plex Mono (`--mono`). v2.css reads these variables — fonts will be wrong if the class is missing.
+3. Shared chrome: **`V2Nav`** (top nav, links live in its `NAV_LINKS` array — update there when adding a route) and **`V2Footer`**.
+4. **Theming** (`useTheme.ts`): light/dark is driven by a `data-theme` attribute set on every `.bqv2` root, persisted to `localStorage['bqv2-theme']`, falling back to `prefers-color-scheme`. An explicit user toggle locks the choice. `ThemeToggle` is the UI. Server always renders light, then the client syncs — expect a brief flash, and never rely on theme during SSR.
+5. **Scroll reveals**: drop a `<RevealMount />` anywhere on the page and tag elements with `className="reveal"`. They fade/slide in via IntersectionObserver, respect `prefers-reduced-motion`, and a 2.5s safety timer force-reveals anything still hidden so a failed observer can't strand content invisibly.
+
+`CryptographySection` is a shared content block used by both `/` and `/protocol`.
+
+### Routes
+
+`src/app/` — `/` (`page.tsx` → `V2Page.tsx`), `/protocol`, `/testnet`, `/faq`. Keep `sitemap.ts` in sync when adding/removing routes.
+
+### Metadata & SEO
+
+This site is SEO-heavy; treat metadata as load-bearing, not boilerplate.
+
+- Root `layout.tsx` defines the title template (`%s | Bitcoin Quantum`), default OG/Twitter tags, `metadataBase`, and injects two JSON-LD blobs (Organization + WebSite) via the `JsonLd` component.
+- Each server-component page exports its own `metadata` with a `title` (slots into the template), `description`, and `alternates.canonical`.
+- **Client pages can't export `metadata`.** `/faq` is `'use client'`, so its metadata lives in a sibling `faq/layout.tsx`. Use this pattern for any interactive page.
+- The home page uses `title: { absolute: ... }` to opt out of the template (so the brand isn't doubled).
+- Other SEO infra: `robots.ts`, `manifest.ts`, `opengraph-image.tsx` (dynamic OG image), `sitemap.ts`.
+
+### Config notes
+
+`next.config.ts` holds the route redirects, security headers, image formats (avif/webp), and the one allowed remote image host (`explorer.bitcoinquantum.com`). React strict mode is on.
+
+## Path alias
+
+`@/*` → `src/*` (see `tsconfig.json`).

--- a/README.md
+++ b/README.md
@@ -1,157 +1,88 @@
 # Bitcoin Quantum Website
 
-A modern, responsive website for Bitcoin Quantum built with Next.js, TypeScript, and Tailwind CSS.
+Marketing site for **Bitcoin Quantum (BTQ)** — Bitcoin rebuilt on post-quantum cryptography. Same 21 million coins, same proof-of-work network, with signatures replaced by NIST-standardized post-quantum primitives (CRYSTALS-Dilithium / ML-DSA, FIPS 204).
 
-## Features
-
-- **Homepage**: Hero section with key features and call-to-action
-- **Introduction**: Detailed explanation of Bitcoin Quantum and quantum-resistant cryptography
-- **Resources**: Wallets, exchanges, tools, and developer resources
-- **FAQ**: Interactive frequently asked questions with category filtering
-- **Responsive Design**: Optimized for desktop, tablet, and mobile devices
-- **Modern Typography**: Uses Manrope, DM Sans, and DM Mono fonts
-- **Quantum-Resistant Branding**: Professional design reflecting security and innovation
-
-## Technologies Used
-
-- **Next.js 15**: React framework with App Router
-- **TypeScript**: Type-safe development
-- **Tailwind CSS v4**: Modern utility-first styling
-- **Google Fonts**: Manrope, DM Sans, and DM Mono
-- **Responsive Design**: Mobile-first approach
+Built with Next.js 15 (App Router), TypeScript, and Tailwind CSS v4. It's a fully static marketing site — no backend, database, or API routes; content is authored directly in the page components.
 
 ## Getting Started
 
 ### Prerequisites
 
 - Node.js 18.17 or later
-- npm or yarn
+- npm
 
-### Installation
-
-1. Clone the repository:
-   ```bash
-   git clone <repository-url>
-   cd website
-   ```
-
-2. Install dependencies:
-   ```bash
-   npm install
-   ```
-
-3. Run the development server:
-   ```bash
-   npm run dev
-   ```
-
-4. Open [http://localhost:3001](http://localhost:3001) in your browser.
-
-### Build for Production
+### Development
 
 ```bash
-npm run build
-npm start
+npm install
+npm run dev      # dev server with Turbopack → http://localhost:3000
 ```
 
-## Project Structure
+### Production
 
+```bash
+npm run build    # production build with Turbopack
+npm start        # serve the build
 ```
-website/
-├── src/
-│   ├── app/
-│   │   ├── layout.tsx          # Root layout
-│   │   ├── page.tsx            # Homepage
-│   │   ├── introduction/
-│   │   │   └── page.tsx        # Introduction page
-│   │   ├── resources/
-│   │   │   └── page.tsx        # Resources page
-│   │   ├── faq/
-│   │   │   └── page.tsx        # FAQ page
-│   │   └── globals.css         # Global styles
-│   └── components/
-│       ├── Header.tsx          # Navigation header
-│       └── Footer.tsx          # Site footer
-├── public/                     # Static assets
-└── package.json
+
+### Lint
+
+```bash
+npm run lint     # eslint (next/core-web-vitals + next/typescript)
 ```
+
+There is no test suite, and type errors surface during `npm run build` (no separate typecheck script).
 
 ## Pages
 
-### Homepage (`/`)
-- Hero section with Bitcoin Quantum branding
-- Feature highlights (Quantum Resistant, Fast & Scalable, Community Driven)
-- Call-to-action sections
+| Route       | Source                            | Notes                                              |
+| ----------- | --------------------------------- | -------------------------------------------------- |
+| `/`         | `src/app/page.tsx` → `V2Page.tsx` | Homepage                                           |
+| `/protocol` | `src/app/protocol/page.tsx`       | Architecture, UTXO model, post-quantum signatures  |
+| `/testnet`  | `src/app/testnet/page.tsx`        | Run a node, mine, download BTQ Core                |
+| `/faq`      | `src/app/faq/page.tsx`            | Interactive FAQ with category filtering            |
 
-### Introduction (`/introduction`)
-- What is Bitcoin Quantum
-- The Quantum Threat explanation
-- Quantum-resistant solution details
-- Key features overview
+Retired routes are 301-redirected in `next.config.ts` (`/introduction → /`, `/resources → /testnet`, `/v2 → /`).
 
-### Resources (`/resources`)
-- Wallets (Core, Lite, Hardware support)
-- Exchanges (Centralized and Decentralized)
-- Network Tools (Block Explorer, Faucet, Mining Calculator, Network Status)
-- Developer Resources (Documentation, GitHub, SDK, Community)
+## Architecture
 
-### FAQ (`/faq`)
-- Interactive FAQ with expandable answers
-- Category filtering (General, Technical, Security, Trading)
-- Comprehensive answers about Bitcoin Quantum
+### Design system ("v2")
 
-## Customization
+All live pages render inside the **v2 design system**, scoped under the `.bqv2` CSS class:
 
-### Fonts
-The site uses three Google Fonts configured in `src/app/layout.tsx`:
-- **Manrope**: Primary headings
-- **DM Sans**: Body text and UI elements
-- **DM Mono**: Code and monospace text
+- **`src/components/v2/v2.css`** — the active styles, fully scoped under `.bqv2` so they can't leak.
+- **`src/app/globals.css`** — an older theme, largely vestigial. New UI should be built against v2.
 
-### Colors
-Primary color scheme defined in `src/app/globals.css`:
-- Primary: `#4d65ff` (blue)
-- Gradients: Blue to purple combinations
-- Semantic colors for different sections
+A page opts into v2 by wrapping its content in an element with the `bqv2` class plus `v2FontClassName`, and importing `v2.css`:
 
-### Styling
-Built with Tailwind CSS v4 using the new `@theme` directive for custom configuration.
+```tsx
+import { v2FontClassName } from '@/components/v2/fonts';
+import '@/components/v2/v2.css';
+
+<div className={`bqv2 ${v2FontClassName}`} data-theme="light">…</div>
+```
+
+Key primitives in `src/components/v2/`:
+
+- **`fonts.ts`** — wires four `next/font/google` families to CSS variables consumed by `v2.css`: Archivo (display), Newsreader (serif), Hanken Grotesk (sans), IBM Plex Mono (mono). Fonts render wrong if `v2FontClassName` is missing.
+- **`V2Nav` / `V2Footer`** — shared page chrome. Nav links live in `V2Nav`'s `NAV_LINKS` array.
+- **`useTheme.ts` / `ThemeToggle.tsx`** — light/dark via a `data-theme` attribute on each `.bqv2` root, persisted to `localStorage` (`bqv2-theme`), falling back to `prefers-color-scheme`. Server renders light, then the client syncs.
+- **`RevealMount.tsx`** — drop it on a page and tag elements with `className="reveal"` for scroll-driven fade/slide-in (respects `prefers-reduced-motion`, with a safety timer so content can't stay hidden).
+- **`CryptographySection.tsx`** — shared content block used by `/` and `/protocol`.
+
+### Metadata & SEO
+
+SEO is load-bearing on this site:
+
+- Root `layout.tsx` sets the title template (`%s | Bitcoin Quantum`), default OG/Twitter tags, `metadataBase`, and injects JSON-LD (Organization + WebSite) via `JsonLd`.
+- Each server-component page exports its own `metadata` (title, description, canonical).
+- **Client pages can't export `metadata`** — `/faq` is `'use client'`, so its metadata lives in `faq/layout.tsx`. Use this pattern for interactive pages.
+- SEO infra: `robots.ts`, `manifest.ts`, `sitemap.ts` (keep in sync with routes), and a dynamic `opengraph-image.tsx`.
+
+### Path alias
+
+`@/*` → `src/*` (see `tsconfig.json`).
 
 ## Deployment
 
-### Vercel (Recommended)
-1. Push to GitHub
-2. Connect repository to Vercel
-3. Deploy automatically
-
-### Other Platforms
-The project is a standard Next.js application and can be deployed to:
-- Netlify
-- AWS Amplify
-- Railway
-- DigitalOcean App Platform
-
-## Development
-
-### Adding New Pages
-1. Create new directory in `src/app/`
-2. Add `page.tsx` file
-3. Update navigation in `src/components/Header.tsx`
-
-### Styling Guidelines
-- Use Tailwind utility classes
-- Follow the established color scheme
-- Use appropriate font classes (`font-manrope`, `font-dm-sans`, `font-dm-mono`)
-- Maintain responsive design patterns
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Test thoroughly
-5. Submit a pull request
-
-## License
-
-This project is open source and available under the [MIT License](LICENSE).
+Deployed on Vercel (includes `@vercel/analytics`). As a standard Next.js app it also runs on any platform supporting Next.js 15.


### PR DESCRIPTION
## Summary
Documentation-only changes to match the live v2 architecture and keep internal/non-public material out of this public repo.

- **Add `CLAUDE.md`** — guidance for Claude Code: the `.bqv2` v2 design system (fonts/theme/reveal), metadata & SEO patterns (incl. the client-page `layout.tsx` gotcha), commands, and the `@/*` alias.
- **Rewrite `README.md`** — reflects the actual live routes (`/`, `/protocol`, `/testnet`, `/faq`) and the v2 design system. Drops the stale `/introduction` + `/resources` sections and the old font/port claims.
- **`.gitignore`** — exclude `/docs/whitepaper/` (in-process whitepaper draft) and `/docs/content/` (internal voice/strategy/Typefully material), so nothing non-public-facing lands in this public repo.

## Notes
No application/source code changes — `src/` is untouched. Nothing under the new gitignored paths is included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)