### PR TITLE
fix(faq): correct block size (8 MB) and block time (1 min) to match btq-core

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -42,7 +42,7 @@ const faqData: FAQItem[] = [
     category: 'general',
     question: 'How is BTQ different from Bitcoin?',
     answer:
-      "Two things change. Signatures switch from ECDSA to CRYSTALS-Dilithium, and block size grows from 1 MB to 64 MiB to absorb the larger post-quantum signatures. Everything else — the UTXO model, the scripting system, the halving schedule, SHA-256 proof-of-work — stays exactly as Bitcoin defined it.",
+      "Two things change. Signatures switch from ECDSA to CRYSTALS-Dilithium, and the block size limit grows from 1 MB to 8 MB to absorb the larger post-quantum signatures. Everything else — the UTXO model, the scripting system, the halving schedule, SHA-256 proof-of-work — stays exactly as Bitcoin defined it.",
   },
   {
     id: 5,
@@ -77,7 +77,7 @@ const faqData: FAQItem[] = [
     category: 'technical',
     question: 'How does BTQ mining work?',
     answer:
-      "Same SHA-256 proof-of-work as Bitcoin — existing ASIC miners work without modification. Difficulty adjustment, reward structure, and 10-minute target block time are all preserved. The only difference is block size: 64 MiB instead of 1 MB, sized for larger post-quantum signatures.",
+      "Same SHA-256 proof-of-work as Bitcoin — existing ASIC miners work without modification. The reward structure and halving schedule are preserved. Two things differ: the target block time is 1 minute (not Bitcoin's 10), and the block size limit is 8 MB instead of 1 MB, sized for larger post-quantum signatures.",
   },
   {
     id: 10,
@@ -91,7 +91,7 @@ const faqData: FAQItem[] = [
     category: 'trading',
     question: 'What are the transaction fees?',
     answer:
-      "Same fee market as Bitcoin: paid per byte, set by congestion, mined by whoever bids highest. Post-quantum signatures are larger, so the 64 MiB block size keeps per-byte fees competitive with what Bitcoin users already expect.",
+      "Same fee market as Bitcoin: paid per byte, set by congestion, mined by whoever bids highest. Post-quantum signatures are larger, so the 8 MB block size keeps per-byte fees competitive with what Bitcoin users already expect.",
   },
   {
     id: 12,


### PR DESCRIPTION
## Summary
The FAQ page stated a **64 MiB** block size and a **10-minute** block time, which contradicted the home and protocol pages (8 MB / 1 min) and the consensus source. Verified the correct values against the `btq-core` sibling repo:

- `MAX_BLOCK_SERIALIZED_SIZE = 8000000  // 8 MB` — `src/consensus/consensus.h`
- `nPowTargetSpacing = 1 * 60  // 1 minute` — `src/kernel/chainparams.cpp` (all networks)

Fixes three `64 MiB` references to **8 MB**, and corrects the claim that a "10-minute target block time" is *preserved* from Bitcoin — BTQ actually targets **1 minute**.

Found by an independent Codex review (item #6) of the open PRs.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` — 0 errors
- [x] No remaining `64 MiB` / `10-minute` strings in the FAQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)