### PR TITLE
fix(guides): align subheading with site convention + mobile polish

### DIFF
--- a/src/components/v2/v2.css
+++ b/src/components/v2/v2.css
@@ -1157,12 +1157,12 @@
   margin: 0 0 16px;
 }
 .bqv2 .guide-header p {
-  font-family: var(--serif);
-  font-style: italic;
-  font-size: clamp(18px, 2.2vw, 22px);
+  font-size: clamp(18px, 1.8vw, 21px);
   color: var(--ink-2);
+  line-height: 1.55;
   max-width: 60ch;
   margin: 0;
+  text-wrap: pretty;
 }
 
 /* two-column body: sticky TOC + article */

--- a/src/components/v2/v2.css
+++ b/src/components/v2/v2.css
@@ -1274,3 +1274,11 @@
 }
 .bqv2 .guide ol.references li:target { color: var(--ink); }
 .bqv2 .guide ol.references em { font-style: italic; color: var(--ink); }
+
+/* Mobile: long opcode names (a <code> label) get their own line so the name
+   doesn't break mid-token and the hex tag doesn't strand at the top-right.
+   Short size-comparison rows use a <span> label and are unaffected. */
+@media (max-width: 620px) {
+  .bqv2 .guide .data-row .row-head { flex-wrap: wrap; }
+  .bqv2 .guide .data-row code.label { flex: 1 1 100%; word-break: normal; }
+}


### PR DESCRIPTION
## Summary
Two small guide refinements, no structural changes.

**1. Subheading style.** The guide header description (subtitle on `/guides` and articles) was rendered in serif italic. The rest of the site doesn't use italics for lead/description text — that's reserved for the editorial `.serif` headline flourish. Now it uses the standard `.lead` treatment: upright sans, same size/color/line-height.

**2. Mobile opcode cards.** On narrow screens the longest opcode name (`OP_CHECKMULTISIGDILITHIUMVERIFY`) broke mid-token and stranded its hex tag at the top-right. Below 620px the `<code>` label now takes its own full line with the hex beneath it, so the name stays intact. Short size-comparison rows (a `<span>` label) are unaffected.

## Notes on scope
The guides are long-form reading, a different content type from the marketing pages, so they keep their own restrained header rather than adopting the landing-page hero. The only real inconsistency was the italic subheading.

## Test plan
- [x] `npm run build` passes; `npm run lint` 0 errors
- [x] Subheading computes to `font-style: normal` in the site sans, matching `.lead`
- [x] Opcode labels single-line with hex below at 390px and 320px; zero horizontal overflow at either width
- [x] Header, TOC, size cards, references, and `/guides` hub verified on mobile