### PR TITLE
Convert guide data-rows to responsive stacked tables

### DIFF
--- a/src/app/guides/quantum-secure-bitcoin/signature-migration/page.tsx
+++ b/src/app/guides/quantum-secure-bitcoin/signature-migration/page.tsx
@@ -248,18 +248,27 @@ export default function SignatureMigrationGuide() {
           The most consequential difference between ECDSA and Dilithium is not speed. Dilithium
           verification (~1.5ms) is actually faster than ECDSA verification (~2ms). It is size.<Cite n={6} />
         </p>
-        <div>
-          {SIZE_ROWS.map((row) => (
-            <div key={row.component} className="data-row">
-              <div className="row-head">
-                <span className="label">{row.component}</span>
-                <span className="ratio">{row.ratio}</span>
-              </div>
-              <div className="detail">
-                ECDSA: {row.ecdsa} &rarr; Dilithium2: {row.dilithium}
-              </div>
-            </div>
-          ))}
+        <div className="table-wrap size-table">
+          <table>
+            <thead>
+              <tr>
+                <th>Component</th>
+                <th>ECDSA</th>
+                <th>Dilithium2</th>
+                <th>Ratio</th>
+              </tr>
+            </thead>
+            <tbody>
+              {SIZE_ROWS.map((row) => (
+                <tr key={row.component}>
+                  <td>{row.component}</td>
+                  <td>{row.ecdsa}</td>
+                  <td>{row.dilithium}</td>
+                  <td className="ratio-col">{row.ratio}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
         <p>
           Every one of these size increases propagates through the system: block sizes must grow to
@@ -278,24 +287,36 @@ export default function SignatureMigrationGuide() {
           The BTQ implementation adds five new opcodes in the unused opcode space above
           Bitcoin&rsquo;s <code>OP_CHECKSIGADD</code>:
         </p>
-        <div>
-          {OPCODES.map((op) => (
-            <div key={op.hex} className="data-row">
-              <div className="row-head">
-                <code className="label">{op.name}</code>
-                <span className="ratio">{op.hex}</span>
-              </div>
-              <div className="detail">{op.purpose}</div>
-              <a
-                className="src"
-                href={`${REPO}/src/script/script.h#L${op.line}`}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                script.h L{op.line} · v0.3.0-testnet
-              </a>
-            </div>
-          ))}
+        <div className="table-wrap op-table">
+          <table>
+            <thead>
+              <tr>
+                <th>Opcode</th>
+                <th>Hex</th>
+                <th>Purpose</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {OPCODES.map((op) => (
+                <tr key={op.hex}>
+                  <td><code>{op.name}</code></td>
+                  <td>{op.hex}</td>
+                  <td style={{ color: 'var(--ink-3)', fontSize: '0.92em' }}>{op.purpose}</td>
+                  <td>
+                    <a
+                      href={`${REPO}/src/script/script.h#L${op.line}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      style={{ fontSize: '0.8em', whiteSpace: 'nowrap' }}
+                    >
+                      L{op.line}
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
         <p>
           A standard Dilithium P2PKH (Pay-to-Public-Key-Hash) script looks almost identical to

--- a/src/components/v2/v2.css
+++ b/src/components/v2/v2.css
@@ -1160,7 +1160,7 @@
   font-size: clamp(18px, 1.8vw, 21px);
   color: var(--ink-2);
   line-height: 1.55;
-  max-width: 60ch;
+  max-width: 72ch;
   margin: 0;
   text-wrap: pretty;
 }

--- a/src/components/v2/v2.css
+++ b/src/components/v2/v2.css
@@ -1275,10 +1275,108 @@
 .bqv2 .guide ol.references li:target { color: var(--ink); }
 .bqv2 .guide ol.references em { font-style: italic; color: var(--ink); }
 
-/* Mobile: long opcode names (a <code> label) get their own line so the name
-   doesn't break mid-token and the hex tag doesn't strand at the top-right.
-   Short size-comparison rows use a <span> label and are unaffected. */
+/* ============================================================
+   guide tables
+   ============================================================ */
+.bqv2 .guide .table-wrap { overflow-x: auto; margin: 0 0 16px; }
+.bqv2 .guide table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95em;
+  min-width: 28rem;
+}
+.bqv2 .guide thead th {
+  font-family: var(--mono);
+  font-size: 0.75em;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-3);
+  font-weight: 600;
+  text-align: right;
+  padding: 0 0 10px 16px;
+  border-bottom: 1px solid var(--line);
+}
+.bqv2 .guide thead th:first-child { text-align: left; padding-left: 0; }
+.bqv2 .guide tbody td {
+  padding: 11px 0 11px 16px;
+  border-bottom: 1px solid var(--line-2);
+  text-align: right;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+}
+.bqv2 .guide tbody td:first-child { text-align: left; padding-left: 0; color: var(--ink-2); }
+.bqv2 .guide tbody tr:last-child td { border-bottom: 0; }
+.bqv2 .guide table .ratio-col { color: var(--accent-ink); font-weight: 700; }
+.bqv2 .guide table code { font-size: 0.88em; }
+
 @media (max-width: 620px) {
-  .bqv2 .guide .data-row .row-head { flex-wrap: wrap; }
-  .bqv2 .guide .data-row code.label { flex: 1 1 100%; word-break: normal; }
+  .bqv2 .guide .size-table { overflow-x: visible; }
+  .bqv2 .guide .size-table table { min-width: 0; }
+  .bqv2 .guide .size-table thead { display: none; }
+  .bqv2 .guide .size-table tbody tr {
+    display: grid;
+    grid-template-columns: 1fr 1fr auto;
+    gap: 2px 10px;
+    padding: 12px 0;
+    border-bottom: 1px solid var(--line-2);
+  }
+  .bqv2 .guide .size-table tbody tr:last-child { border-bottom: 0; }
+  .bqv2 .guide .size-table tbody td {
+    padding: 0;
+    border: none;
+    text-align: left;
+    font-size: 0.9em;
+    color: var(--ink-3);
+  }
+  .bqv2 .guide .size-table tbody td:first-child {
+    grid-column: 1 / -1;
+    font-weight: 600;
+    color: var(--ink);
+    font-size: 1em;
+    margin-bottom: 1px;
+  }
+  .bqv2 .guide .size-table tbody td:nth-child(3) { color: var(--ink); }
+  .bqv2 .guide .size-table tbody td:nth-child(4) {
+    color: var(--accent-ink);
+    font-weight: 700;
+    text-align: right;
+  }
+
+  .bqv2 .guide .op-table { overflow-x: visible; }
+  .bqv2 .guide .op-table table { min-width: 0; }
+  .bqv2 .guide .op-table thead { display: none; }
+  .bqv2 .guide .op-table tbody tr {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 2px 10px;
+    padding: 12px 0;
+    border-bottom: 1px solid var(--line-2);
+  }
+  .bqv2 .guide .op-table tbody tr:last-child { border-bottom: 0; }
+  .bqv2 .guide .op-table tbody td {
+    padding: 0;
+    border: none;
+    text-align: left;
+    color: var(--ink-3);
+    font-size: 0.88em;
+  }
+  .bqv2 .guide .op-table tbody td:first-child {
+    grid-column: 1 / -1;
+    font-weight: 600;
+    color: var(--ink);
+    font-size: 1em;
+    margin-bottom: 1px;
+  }
+  .bqv2 .guide .op-table tbody td:first-child code {
+    font-size: inherit;
+    word-break: break-all;
+  }
+  .bqv2 .guide .op-table tbody td:nth-child(2) {
+    font-family: var(--mono);
+    font-size: 0.82em;
+    color: var(--ink-2);
+  }
+  .bqv2 .guide .op-table tbody td:nth-child(4) {
+    text-align: right;
+  }
 }


### PR DESCRIPTION
Converts the two data tables in the signature-migration guide from card-style `.data-row` divs to proper `<table>` elements with:

- Clean header row with uppercase mono labels
- Right-aligned numeric cells with `tabular-nums`
- Ratio column highlighted in accent color
- Opcodes table with inline source link

**Responsive stacking** — on mobile (<620px), both tables hide the thead and stack each row into two lines: the label (component/opcode) on top, then the values side-by-side beneath.

This supersedes the `.data-row` mobile opcode-wrapping fix from #38 — those rows are now tables, and the responsive table CSS handles the same long-opcode case on mobile.

**Also:** widens the guide deck (subheading) measure from `60ch` to `72ch` so it matches the article column's measure and reads as a fuller deck without stretching to unreadable line lengths.

## Test plan
- `npm run build` passes (18/18 static pages).
- Tables render correctly on desktop and stack cleanly on mobile (<620px).