### PR TITLE
feat(guides): add 'Why Taproot Is Quantum-Vulnerable' (guide 3 of the series)

### DIFF
--- a/src/app/guides/_data/guides.ts
+++ b/src/app/guides/_data/guides.ts
@@ -14,4 +14,12 @@ export const RELEASED_GUIDES: GuideListing[] = [
       "What changing Bitcoin's signature algorithm actually requires: opcodes, " +
       'size impacts, wallet changes, and running both schemes in one block.',
   },
+  {
+    slug: 'taproot-quantum-vulnerability',
+    href: '/guides/quantum-secure-bitcoin/taproot-quantum-vulnerability',
+    title: 'Why Taproot Is Quantum-Vulnerable',
+    blurb:
+      'Taproot exposes the public key on-chain, so a quantum-resistant script in a ' +
+      "P2TR container is false security. BIP-360's P2MR removes the key path entirely.",
+  },
 ];

--- a/src/app/guides/quantum-secure-bitcoin/taproot-quantum-vulnerability/opengraph-image.tsx
+++ b/src/app/guides/quantum-secure-bitcoin/taproot-quantum-vulnerability/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderGuideOg, OG_SIZE, OG_CONTENT_TYPE } from '../../_og';
+
+export const runtime = 'nodejs';
+export const alt = 'Why Taproot Is Quantum-Vulnerable — Bitcoin Quantum guide';
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+
+export default function Image() {
+  return renderGuideOg({ eyebrow: 'GUIDE · QUANTUM-SECURE BITCOIN', title: 'Why Taproot Is Quantum-Vulnerable' });
+}

--- a/src/app/guides/quantum-secure-bitcoin/taproot-quantum-vulnerability/page.tsx
+++ b/src/app/guides/quantum-secure-bitcoin/taproot-quantum-vulnerability/page.tsx
@@ -1,0 +1,388 @@
+import type { Metadata } from 'next';
+import GuideLayout from '../../_components/GuideLayout';
+
+const TABLE_OF_CONTENTS = [
+  { id: 'taproot-recap', title: 'What Taproot Does' },
+  { id: 'key-path-problem', title: 'The Key-Path Problem' },
+  { id: 'false-security', title: 'Dilithium in Taproot: False Security' },
+  { id: 'sigop-dos', title: 'The Sigop DoS Discovery' },
+  { id: 'op-success-bypass', title: 'The OP_SUCCESSx Bypass' },
+  { id: 'bip-360-p2mr', title: 'BIP-360 and Pay-to-Merkle-Root' },
+  { id: 'p2mr-implementation', title: 'P2MR in Practice' },
+  { id: 'implications', title: 'Implications for Bitcoin' },
+  { id: 'references', title: 'References' },
+];
+
+interface Reference {
+  id: string;
+  cite: React.ReactNode;
+}
+
+const REPO = 'https://github.com/btq-ag/btq-core/blob/v0.3.0-testnet';
+
+const REFERENCES: Reference[] = [
+  {
+    id: 'ref-1',
+    cite: (
+      <>
+        BTQ-Core (v0.3.0-testnet): Dilithium opcodes disabled in the tapscript execution context in{' '}
+        <a href={`${REPO}/src/script/interpreter.cpp#L1274-L1277`} target="_blank" rel="noopener noreferrer">
+          interpreter.cpp L1274&ndash;1277
+        </a>
+        , with the error string defined in{' '}
+        <a href={`${REPO}/src/script/script_error.cpp#L114-L115`} target="_blank" rel="noopener noreferrer">
+          script_error.cpp L114&ndash;115
+        </a>
+        .
+      </>
+    ),
+  },
+  {
+    id: 'ref-2',
+    cite: (
+      <>
+        BTQ-Core (v0.3.0-testnet): Dilithium signature opcodes added to the sigop-counting function in{' '}
+        <a href={`${REPO}/src/script/script.cpp#L163-L186`} target="_blank" rel="noopener noreferrer">
+          script.cpp L163&ndash;186
+        </a>
+        .
+      </>
+    ),
+  },
+  {
+    id: 'ref-3',
+    cite: (
+      <>
+        BTQ-Core (v0.3.0-testnet): <code>OP_SUCCESSx</code> range narrowed from 0xbb to 0xc0, excluding the
+        Dilithium opcode range, in{' '}
+        <a href={`${REPO}/src/script/script.cpp#L347-L356`} target="_blank" rel="noopener noreferrer">
+          script.cpp L347&ndash;356
+        </a>
+        .
+      </>
+    ),
+  },
+  {
+    id: 'ref-4',
+    cite: (
+      <>
+        BTQ-Core (v0.3.0-testnet): P2MR (SegWit version 2) verification and Dilithium re-enabling in
+        the P2MR context in{' '}
+        <a href={`${REPO}/src/script/interpreter.cpp#L2192-L2226`} target="_blank" rel="noopener noreferrer">
+          interpreter.cpp L2192&ndash;2226
+        </a>
+        .
+      </>
+    ),
+  },
+  {
+    id: 'ref-5',
+    cite: (
+      <>
+        Wuille, Nick &amp; Towns.{' '}
+        <em>BIP-341: Taproot — SegWit version 1 spending rules</em> and{' '}
+        <em>BIP-342: Validation of Taproot scripts</em> (the <code>OP_SUCCESSx</code> upgrade mechanism).{' '}
+        <a href="https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki" target="_blank" rel="noopener noreferrer">
+          bip-0341
+        </a>
+        ,{' '}
+        <a href="https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki" target="_blank" rel="noopener noreferrer">
+          bip-0342
+        </a>
+        .
+      </>
+    ),
+  },
+  {
+    id: 'ref-6',
+    cite: (
+      <>
+        Beast.{' '}
+        <em>BIP-360: Pay-to-Merkle-Root (P2MR)</em>, originally drafted as P2QRH.{' '}
+        <a href="https://bip360.org/" target="_blank" rel="noopener noreferrer">
+          bip360.org
+        </a>
+      </>
+    ),
+  },
+];
+
+const DESC =
+  "Taproot's key-path spend exposes public keys on-chain, making P2TR outputs " +
+  'vulnerable to quantum key extraction. BIP-360’s P2MR removes the key path entirely — ' +
+  'here’s why that matters and how it was implemented.';
+
+export const metadata: Metadata = {
+  title: 'Why Taproot Is Quantum-Vulnerable: From BIP-360 to P2MR',
+  description: DESC,
+  alternates: { canonical: '/guides/quantum-secure-bitcoin/taproot-quantum-vulnerability' },
+  openGraph: {
+    title: 'Why Taproot Is Quantum-Vulnerable',
+    description: 'The key-path problem, BIP-360, and the first production P2MR implementation.',
+    url: '/guides/quantum-secure-bitcoin/taproot-quantum-vulnerability',
+    type: 'article',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Why Taproot Is Quantum-Vulnerable',
+    description: 'The key-path problem, BIP-360, and the first production P2MR implementation.',
+  },
+};
+
+function Cite({ n }: { n: number }) {
+  return (
+    <sup className="cite">
+      <a href={`#ref-${n}`}>{n}</a>
+    </sup>
+  );
+}
+
+export default function TaprootQuantumVulnerabilityGuide() {
+  return (
+    <GuideLayout
+      title="Why Taproot Is Quantum-Vulnerable"
+      description="Taproot's key-path spend exposes public keys on-chain, creating a quantum attack surface that no amount of post-quantum scripting can fix. BIP-360's P2MR removes the vulnerability at the root."
+      tableOfContents={TABLE_OF_CONTENTS}
+    >
+      <section id="taproot-recap">
+        <h2>What Taproot Does</h2>
+        <p>
+          Taproot (BIP-340/341/342), activated on Bitcoin in November 2021, introduced two major
+          innovations. First, it replaced ECDSA with Schnorr signatures for the key-path spend,
+          enabling signature aggregation and improved privacy. Second, it introduced a Merkleized
+          Alternative Script Tree (MAST) that allows complex spending conditions to be committed to a
+          single on-chain hash, with only the branch used in a spend revealed at transaction time.
+        </p>
+        <p>
+          A Taproot output (P2TR) encodes a 32-byte &ldquo;tweaked&rdquo; public key directly in the
+          scriptPubKey:
+        </p>
+        <div className="script-block">
+          <div><span className="tag">P2TR output:</span> OP_1 &lt;32-byte tweaked public key&gt;</div>
+        </div>
+        <p>
+          This tweaked key is derived from an internal public key combined with the Merkle root of the
+          script tree. There are two spending paths: the <strong>key path</strong> (provide a valid
+          Schnorr signature for the tweaked key) and the <strong>script path</strong> (reveal one
+          script branch from the Merkle tree and satisfy it). The key path is the fast, private,
+          compact option. The script path is the fallback for complex conditions.
+        </p>
+      </section>
+
+      <section id="key-path-problem">
+        <h2>The Key-Path Problem</h2>
+        <p>
+          The quantum vulnerability: the tweaked public key is <strong>always visible on-chain</strong>{' '}
+          in the scriptPubKey, from the moment the output is created. Unlike P2PKH or P2WPKH outputs
+          (where only a hash of the public key appears on-chain), P2TR outputs expose the actual public
+          key &mdash; in a form that can be reversed to the internal key.
+        </p>
+        <p>
+          A quantum computer running Shor&rsquo;s algorithm can derive the private key from this exposed
+          public key. With the private key, the attacker can spend the output through the key path
+          &mdash; <em>regardless of what scripts exist in the script tree</em>.
+        </p>
+        <p>
+          This creates a paradox for post-quantum security: you could write a perfectly secure
+          Dilithium signature check in a Taproot script leaf, creating what appears to be a
+          quantum-resistant spending condition. But an attacker with a CRQC would simply ignore your
+          script entirely and spend through the key path. The quantum-resistant script is inside a
+          quantum-vulnerable container.
+        </p>
+        <p>
+          Critically, this is not a timing vulnerability like P2PKH (where the public key is only
+          exposed when you spend). P2TR outputs are vulnerable from the moment they are created. The
+          attacker has unlimited time to compute the private key &mdash; no race condition, no mempool
+          front-running required.
+        </p>
+      </section>
+
+      <section id="false-security">
+        <h2>Dilithium in Taproot: False Security</h2>
+        <p>
+          When the BTQ project first added Dilithium opcodes to its scripting language, they were
+          available in all script execution contexts &mdash; including Taproot tapscript. This seemed
+          logical: if you have quantum-resistant signature verification, why not use it everywhere?
+        </p>
+        <p>
+          The problem became apparent during security review. Allowing Dilithium opcodes in Taproot
+          tapscript provides a <strong>false sense of security</strong>. A user might construct a P2TR
+          output with a script leaf containing an <code>OP_CHECKSIGDILITHIUM</code> check and believe
+          their funds are quantum-safe. They are not. The key-path bypass makes the Dilithium script
+          irrelevant.
+        </p>
+        <p>
+          The fix was to explicitly disable all five Dilithium opcodes in the tapscript execution
+          context, following the same pattern used for <code>OP_CHECKMULTISIG</code> (which is also
+          disabled in tapscript). Any attempt to execute a Dilithium opcode in a P2TR script now fails
+          with a specific error message: <em>&ldquo;Dilithium opcodes are not available in tapscript
+          (P2TR is quantum-vulnerable).&rdquo;</em><Cite n={1} />
+        </p>
+      </section>
+
+      <section id="sigop-dos">
+        <h2>The Sigop DoS Discovery</h2>
+        <p>
+          The investigation into Dilithium-in-Taproot was triggered by a separate vulnerability
+          reported by the pseudonymous security researcher masato83. The issue: Bitcoin&rsquo;s sigop
+          counting function (<code>GetTransactionSigOpCost</code>) did not count Dilithium opcodes,
+          meaning they did not contribute toward the per-block sigop limit.
+        </p>
+        <p>
+          While 80,000 unique Dilithium signatures cannot physically fit in a block (each is 2,420
+          bytes), a script can duplicate signatures already on the stack:
+        </p>
+        <div className="script-block">
+          <div>&lt;sig&gt; &lt;pubkey&gt;</div>
+          <div>OP_2DUP OP_CHECKSIGDILITHIUMVERIFY</div>
+          <div>OP_2DUP OP_CHECKSIGDILITHIUMVERIFY</div>
+          <div>OP_2DUP OP_CHECKSIGDILITHIUMVERIFY</div>
+          <div>... (repeated)</div>
+        </div>
+        <p>
+          Each <code>OP_2DUP</code> copies the signature and key without adding data to the block,
+          while each <code>OP_CHECKSIGDILITHIUMVERIFY</code> performs a full Dilithium verification
+          (~1.5ms). Without sigop counting, a block could contain scripts forcing thousands of
+          Dilithium verifications, creating a denial-of-service vector where block validation takes far
+          longer than expected.
+        </p>
+        <p>
+          The fix was straightforward: add all four Dilithium signature opcodes to the sigop counting
+          function, applying the same counting rules as their ECDSA equivalents. Single-sig opcodes
+          count as 1 sigop; multi-sig opcodes use the same N-of-M counting logic. This brings Dilithium
+          operations under the existing resource control framework.<Cite n={2} />
+        </p>
+      </section>
+
+      <section id="op-success-bypass">
+        <h2>The OP_SUCCESSx Bypass</h2>
+        <p>
+          While investigating the sigop issue, the BTQ team discovered a more critical vulnerability.
+          In BIP-342&rsquo;s tapscript rules, opcodes in the range 0xbb&ndash;0xfe are designated as{' '}
+          <code>OP_SUCCESSx</code> &mdash; opcodes reserved for future soft-fork upgrades. Any tapscript
+          containing an OP_SUCCESSx opcode <strong>unconditionally succeeds without validation</strong>.
+        </p>
+        <p>
+          The Dilithium opcodes were assigned values 0xbb through 0xbf &mdash; squarely within the
+          OP_SUCCESSx range. This meant that any Taproot script containing a Dilithium opcode would
+          automatically succeed, regardless of whether the signature was valid, present, or even the
+          right type. <strong>Anyone could spend any Taproot output containing a Dilithium opcode in
+          its script tree.</strong>
+        </p>
+        <p>
+          The fix narrowed the OP_SUCCESSx range from &ldquo;0xbb to 0xfe&rdquo; to &ldquo;0xc0 to
+          0xfe&rdquo;, explicitly excluding the Dilithium opcode range. Combined with disabling
+          Dilithium opcodes in tapscript entirely, this eliminated both the bypass vulnerability and the
+          false-security risk. The discovery underscores why post-quantum modifications to
+          Bitcoin&rsquo;s consensus rules require exhaustive analysis of interaction effects &mdash;
+          opcode assignment is not just a numbering exercise.<Cite n={3} />
+        </p>
+      </section>
+
+      <section id="bip-360-p2mr">
+        <h2>BIP-360 and Pay-to-Merkle-Root</h2>
+        <p>
+          Disabling Dilithium in Taproot is the correct short-term fix, but it leaves a gap: there is
+          no script-tree output type where Dilithium signatures can be used with genuine quantum
+          resistance. You can use Dilithium in legacy-style P2PKH scripts, but you lose Taproot&rsquo;s
+          privacy benefits (unrevealed branches) and efficiency (compact key-path spends).
+        </p>
+        <p>
+          The long-term solution comes from BIP-360, authored by Hunter Beast. BIP-360 proposes
+          Pay-to-Merkle-Root (P2MR) &mdash; a new SegWit version 2 output type that takes everything
+          valuable from Taproot and removes the quantum-vulnerable element.
+        </p>
+        <p>
+          The key insight: remove the key path entirely. Instead of committing to a tweaked public key
+          (which exposes the key on-chain), P2MR commits only to the Merkle root of the script tree:
+        </p>
+        <div className="script-block">
+          <div><span className="tag">P2TR (v1):</span> OP_1 &lt;tweaked-pubkey&gt; &larr; public key exposed, quantum-vulnerable</div>
+          <div><span className="tag">P2MR (v2):</span> OP_2 &lt;script-tree-root&gt; &larr; no public key, quantum-resistant</div>
+        </div>
+        <p>
+          With no public key on-chain, there is no key-path bypass. The only way to spend a P2MR output
+          is through the script path &mdash; revealing one branch of the Merkle tree and satisfying its
+          conditions. If that branch contains a Dilithium signature check, the output is genuinely
+          quantum-resistant: the public key only appears at spend time (in the witness), and the
+          signature scheme is immune to Shor&rsquo;s algorithm.<Cite n={4} />
+        </p>
+      </section>
+
+      <section id="p2mr-implementation">
+        <h2>P2MR in Practice</h2>
+        <p>
+          The BTQ project implemented P2MR as described in BIP-360, making it the first UTXO chain to
+          ship a production quantum-resistant script tree output type. The implementation includes:
+        </p>
+        <ul>
+          <li>
+            <strong>New address format</strong>: <code>bc1z...</code> on mainnet (SegWit version 2,
+            bech32m encoding). The &ldquo;z&rdquo; prefix visually distinguishes P2MR addresses from
+            Taproot&rsquo;s <code>bc1p...</code>.
+          </li>
+          <li>
+            <strong>Compact control blocks</strong>: P2MR control blocks are <code>1 + 32*m</code>{' '}
+            bytes (where m is the Merkle path depth). P2TR control blocks are <code>33 + 32*m</code>{' '}
+            bytes because they include the 32-byte internal public key. P2MR saves 32 bytes per spend.
+          </li>
+          <li>
+            <strong>Dilithium opcodes re-enabled</strong>: All five Dilithium opcodes work inside P2MR
+            tapscript. They remain disabled in P2TR tapscript. The execution context determines which
+            opcodes are available.
+          </li>
+          <li>
+            <strong>No key path</strong>: Witness stacks with fewer than 2 elements are rejected. This
+            enforces the script-path-only rule at the consensus level.
+          </li>
+          <li>
+            <strong>Parity bit enforcement</strong>: The control block parity bit must be 1, per the
+            BIP-360 specification.
+          </li>
+        </ul>
+        <p>
+          The implementation was validated with 15 test groups covering output format, script path
+          spending, key path rejection, cross-tree spend prevention, control block format validation,
+          address encoding, and multi-input transactions. Every successful spend was mined into a block
+          and verified at the consensus level &mdash; not just mempool acceptance.<Cite n={4} />
+        </p>
+      </section>
+
+      <section id="implications">
+        <h2>Implications for Bitcoin</h2>
+        <p>
+          The Taproot quantum vulnerability is not theoretical &mdash; it is a direct consequence of the
+          P2TR output format. Every Taproot output on the Bitcoin blockchain today exposes a public key
+          that a future quantum computer could use to derive the private key and steal the funds. As of
+          early 2026, the amount of bitcoin held in Taproot outputs continues to grow.
+        </p>
+        <p>
+          For Bitcoin Core, the path forward likely involves adopting something similar to
+          BIP-360&rsquo;s P2MR, whether through that specific proposal or an evolved version. The
+          engineering is straightforward: it is a SegWit version 2 output type that requires no changes
+          to the existing Taproot infrastructure &mdash; P2TR continues to work for anyone who uses it,
+          and P2MR adds a new quantum-resistant option.
+        </p>
+        <p>
+          What the BTQ implementation demonstrates is that P2MR is not just a specification &mdash; it
+          can be built, tested, and deployed in a Bitcoin-compatible codebase. The vulnerabilities
+          discovered along the way (sigop DoS, OP_SUCCESSx bypass, false security of
+          Dilithium-in-Taproot) are exactly the kind of findings that justify implementing PQC on a
+          separate network first. These issues are far cheaper to discover in a fork than in Bitcoin
+          mainnet.
+        </p>
+      </section>
+
+      <section id="references">
+        <h2>References</h2>
+        <ol className="references">
+          {REFERENCES.map((ref) => (
+            <li key={ref.id} id={ref.id}>
+              {ref.cite}
+            </li>
+          ))}
+        </ol>
+      </section>
+    </GuideLayout>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -36,6 +36,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
+      url: `${baseUrl}/guides/quantum-secure-bitcoin/taproot-quantum-vulnerability`,
+      lastModified: currentDate,
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/faq`,
       lastModified: currentDate,
       changeFrequency: 'monthly',


### PR DESCRIPTION
Ports the **taproot-quantum-vulnerability** article from the qdayanon content engine into the v2 guide system. Guide 3 of the quantum-secure-bitcoin series (after signature-migration and block-size-tradeoffs #39).

## What's in it
- `quantum-secure-bitcoin/taproot-quantum-vulnerability/page.tsx` — the article, converted to the v2 `GuideLayout` (semantic HTML styled by `.guide`, `.script-block` for mono blocks, `<Cite>` superscripts + a References section).
- `…/opengraph-image.tsx` — dynamic OG via the shared `renderGuideOg`.
- Registered in `_data/guides.ts` (hub listing) and `sitemap.ts`.

## Conversion notes
- Stripped the source article's Tailwind utility classes / hardcoded colors; no `SITE_*` constants — uses relative canonical + the template title, matching the other guides.
- The source's inline "View source" footers were collected into a **References** section.
- **btq-core source links kept at `v0.3.0-testnet`**, consistent with the existing guides. Per direction, these are **not yet re-verified** against latest btq-core — that pass happens once the audit findings are merged.

## Verification
- `npm run lint` — clean (only the 2 pre-existing warnings in `opengraph-image.tsx`).
- `npm run build` — succeeds; route and its OG image prerender as static.

🤖 Generated with [Claude Code](https://claude.com/claude-code)