### PR TITLE
Feat/guide block size tradeoffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ yarn-error.log*
 # not for the public repo
 /docs/content/
 
+# internal dev-team reference docs (storage model PDFs, reconciliation notes)
+# — local-only, not for the public repo
+/docs/reference/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -42,7 +42,7 @@ const faqData: FAQItem[] = [
     category: 'general',
     question: 'How is BTQ different from Bitcoin?',
     answer:
-      "Two things change. Signatures switch from ECDSA to CRYSTALS-Dilithium, and the block size limit grows from 1 MB to 8 MB to absorb the larger post-quantum signatures. Everything else — the UTXO model, the scripting system, the halving schedule, SHA-256 proof-of-work — stays exactly as Bitcoin defined it.",
+      "The signature scheme switches from ECDSA to CRYSTALS-Dilithium, and a few parameters are retuned to absorb the larger signatures: the block weight limit doubles (Bitcoin's ~4 MB cap becomes 8 MB), and blocks arrive every minute instead of every ten. The emission curve is preserved — same 21 million cap and ~4-year halving cadence, with the interval rescaled to match the faster blocks. Everything else — the UTXO model, the scripting system, SHA-256 proof-of-work — is exactly as Bitcoin defined it.",
   },
   {
     id: 5,

--- a/src/app/guides/_data/guides.ts
+++ b/src/app/guides/_data/guides.ts
@@ -17,7 +17,7 @@ export const RELEASED_GUIDES: GuideListing[] = [
   {
     slug: 'block-size-tradeoffs',
     href: '/guides/quantum-secure-bitcoin/block-size-tradeoffs',
-    title: 'The 15x Problem',
+    title: 'The 20x Problem',
     blurb:
       'Why quantum-resistant transactions need bigger blocks, and how every ' +
       'parameter change cascades through emission schedules, witness economics, ' +

--- a/src/app/guides/_data/guides.ts
+++ b/src/app/guides/_data/guides.ts
@@ -14,4 +14,13 @@ export const RELEASED_GUIDES: GuideListing[] = [
       "What changing Bitcoin's signature algorithm actually requires: opcodes, " +
       'size impacts, wallet changes, and running both schemes in one block.',
   },
+  {
+    slug: 'block-size-tradeoffs',
+    href: '/guides/quantum-secure-bitcoin/block-size-tradeoffs',
+    title: 'The 15x Problem',
+    blurb:
+      'Why quantum-resistant transactions need bigger blocks, and how every ' +
+      'parameter change cascades through emission schedules, witness economics, ' +
+      'chain growth, and node viability.',
+  },
 ];

--- a/src/app/guides/quantum-secure-bitcoin/block-size-tradeoffs/opengraph-image.tsx
+++ b/src/app/guides/quantum-secure-bitcoin/block-size-tradeoffs/opengraph-image.tsx
@@ -1,10 +1,10 @@
 import { renderGuideOg, OG_SIZE, OG_CONTENT_TYPE } from '../../_og';
 
 export const runtime = 'nodejs';
-export const alt = 'The 15x Problem — Bitcoin Quantum guide';
+export const alt = 'The 20x Problem — Bitcoin Quantum guide';
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 
 export default function Image() {
-  return renderGuideOg({ eyebrow: 'GUIDE · QUANTUM-SECURE BITCOIN', title: 'The 15x Problem' });
+  return renderGuideOg({ eyebrow: 'GUIDE · QUANTUM-SECURE BITCOIN', title: 'The 20x Problem' });
 }

--- a/src/app/guides/quantum-secure-bitcoin/block-size-tradeoffs/opengraph-image.tsx
+++ b/src/app/guides/quantum-secure-bitcoin/block-size-tradeoffs/opengraph-image.tsx
@@ -1,0 +1,10 @@
+import { renderGuideOg, OG_SIZE, OG_CONTENT_TYPE } from '../../_og';
+
+export const runtime = 'nodejs';
+export const alt = 'The 15x Problem — Bitcoin Quantum guide';
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+
+export default function Image() {
+  return renderGuideOg({ eyebrow: 'GUIDE · QUANTUM-SECURE BITCOIN', title: 'The 15x Problem' });
+}

--- a/src/app/guides/quantum-secure-bitcoin/block-size-tradeoffs/page.tsx
+++ b/src/app/guides/quantum-secure-bitcoin/block-size-tradeoffs/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import GuideLayout from '../../_components/GuideLayout';
 
 const TABLE_OF_CONTENTS = [
-  { id: 'the-15x-problem', title: 'The 15x Problem' },
+  { id: 'the-20x-problem', title: 'The 20x Problem' },
   { id: 'block-capacity', title: 'Block Capacity Impact' },
   { id: 'witness-discount', title: 'The Witness Discount Question' },
   { id: 'chain-growth', title: 'Chain Growth and Node Viability' },
@@ -16,18 +16,18 @@ const DESC =
   'witness economics, emission schedules, and chain growth. A technical analysis of the tradeoffs.';
 
 export const metadata: Metadata = {
-  title: 'The 15x Problem: Why Quantum-Resistant Transactions Need Bigger Blocks',
+  title: 'The 20x Problem: Why Quantum-Resistant Transactions Need Bigger Blocks',
   description: DESC,
   alternates: { canonical: '/guides/quantum-secure-bitcoin/block-size-tradeoffs' },
   openGraph: {
-    title: 'The 15x Problem',
+    title: 'The 20x Problem',
     description: 'Why quantum-resistant transactions need bigger blocks, and what that costs.',
     url: '/guides/quantum-secure-bitcoin/block-size-tradeoffs',
     type: 'article',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'The 15x Problem',
+    title: 'The 20x Problem',
     description: 'Why quantum-resistant transactions need bigger blocks.',
   },
 };
@@ -115,8 +115,8 @@ const REFERENCES: Reference[] = [
         </a>
         ). Because weight = 15 &times; (non-witness size) + (total size), weight reaches its cap before
         serialized size does for any transaction that carries non-witness data, so weight &mdash; not the
-        8 MB figure &mdash; is the binding constraint. A weight-full block of ordinary single-input
-        Dilithium payments holds ~1,540 transactions and is ~5.9 MB on disk (~8.5 GB/day); the 8 MB block
+        8 MB figure &mdash; is the binding constraint. A weight-full block of ordinary two-input
+        Dilithium payments holds ~800 transactions and is ~6.1 MB on disk (~8.8 GB/day); the 8 MB block
         and ~11.5 GB/day figures are the asymptotic ceiling, approached only by witness-dominated blocks
         where non-witness data is negligible. The Bitcoin and BTQ columns above are stated as this
         serialized ceiling and computed the same way, so the comparison is like-for-like. The per-block
@@ -136,32 +136,33 @@ function Cite({ n }: { n: number }) {
 }
 
 const CHAIN_GROWTH = [
-  { metric: 'Full-block chain growth / 10 min', btc: '~4 MB', btq: '~80 MB' },
-  { metric: 'Chain growth / day (full blocks)', btc: '~576 MB', btq: '~11.5 GB' },
-  { metric: 'UTXO set growth / 10 min (full blocks)', btc: '~1 MB', btq: '~5.3 MB' },
+  { metric: 'Chain growth / day — full blocks (ceiling)', btc: '~576 MB', btq: '~11.5 GB' },
+  { metric: 'Chain growth / year — full blocks (ceiling)', btc: '~210 GB', btq: '~4.2 TB' },
+  { metric: 'Chain growth / year — realistic (~50% full)', btc: '~90–100 GB', btq: '~1 TB' },
+  { metric: 'UTXO-set growth / year — normal traffic', btc: '~1–2 GB', btq: '~3 GB' },
 ];
 
 export default function BlockSizeTradeoffsGuide() {
   return (
     <GuideLayout
-      title="The 15x Problem"
+      title="The 20x Problem"
       description="Why quantum-resistant transactions need bigger blocks, and how every parameter change cascades through emission schedules, witness economics, chain growth, and node viability."
       tableOfContents={TABLE_OF_CONTENTS}
     >
-      <section id="the-15x-problem">
-        <h2>The 15x Problem</h2>
+      <section id="the-20x-problem">
+        <h2>The 20x Problem</h2>
         <p>
-          A typical Bitcoin transaction with one input and two outputs (a payment and change) is
-          roughly 250 bytes. The same transaction signed with Dilithium2 is approximately 3,824 bytes,
-          about 15 times larger. This single ratio drives nearly every protocol-level change required
-          to build a quantum-resistant Bitcoin.
+          A typical Bitcoin transaction with two inputs and two outputs (the shape most planning
+          models use as the reference) is roughly 372 bytes. The same transaction signed with
+          Dilithium2 is approximately 7,636 bytes, about 20 times larger. This single ratio drives
+          nearly every protocol-level change required to build a quantum-resistant Bitcoin.
         </p>
         <p>
-          The size increase comes from the witness data. A Dilithium witness stack contains a 2,421-byte
-          signature (2,420 bytes plus one byte for the sighash type) and a 1,312-byte public key. Compare
-          that to ECDSA&rsquo;s ~72-byte signature and 33-byte compressed public key. The transaction
-          header, input outpoints, and output scripts stay roughly the same size. The authentication data
-          is what explodes.
+          The size increase comes from the witness data. Each input carries its own Dilithium witness
+          stack: a 2,421-byte signature (2,420 bytes plus one byte for the sighash type) and a 1,312-byte
+          public key, roughly 3,733 bytes per input. Compare that to ECDSA&rsquo;s ~72-byte signature and
+          33-byte compressed public key. The transaction header, input outpoints, and output scripts stay
+          roughly the same size. The authentication data is what explodes.
         </p>
         <p>
           This is not a flaw in Dilithium. It is the cost of quantum resistance. Every post-quantum
@@ -177,19 +178,19 @@ export default function BlockSizeTradeoffsGuide() {
         <p>
           Bitcoin&rsquo;s block weight limit is 4,000,000 weight units (4 MW), which translates to a
           maximum serialized block size of roughly 4 MB once you account for the SegWit witness discount.
-          With 250-byte ECDSA transactions, that fits approximately 16,000 transactions per block.
+          With 372-byte ECDSA transactions, that fits approximately 10,750 transactions per block.
         </p>
         <p>
-          With 3,824-byte Dilithium transactions, the same 4 MB block fits approximately 1,050
-          transactions, a 15x reduction in throughput at the same block size. To maintain even
+          With 7,636-byte Dilithium transactions, the same 4 MB block fits approximately 520
+          transactions, a 20x reduction in throughput at the same block size. To maintain even
           Bitcoin&rsquo;s current transaction throughput (already considered low), you need larger blocks.
         </p>
         <p>
           The BTQ project raised <code>MAX_BLOCK_SERIALIZED_SIZE</code> to 8 MB and{' '}
           <code>MAX_BLOCK_WEIGHT</code> to 8,000,000 weight units. The binding consensus limit is block
-          weight, not serialized size,<Cite n={5} /> so a weight-full block of ordinary single-input
-          Dilithium transactions holds roughly 1,540 of them. (Dividing the 8 MB size cap by transaction
-          size suggests ~2,100, but a block of that many would exceed the 8 MW weight limit.) The sigops
+          weight, not serialized size,<Cite n={5} /> so a weight-full block of ordinary two-input
+          Dilithium transactions holds roughly 800 of them. (Dividing the 8 MB size cap by transaction
+          size suggests ~1,050, but a block of that many would exceed the 8 MW weight limit.) The sigops
           limit was doubled to 80,000 to cover the validation cost of the larger signatures.<Cite n={1} />
         </p>
         <p>
@@ -264,19 +265,22 @@ export default function BlockSizeTradeoffsGuide() {
         </div>
 
         <p>
-          These figures are the absolute serialized ceiling, 8 MB per block × 1,440 blocks per day, and
-          assume full blocks, a worst case for a young network.<Cite n={5} /> In practice, BTQ blocks are
-          far from full during bootstrapping, and a full block of ordinary Dilithium payments is weight-limited
-          to ~5.9 MB (~8.5 GB/day); the 11.5 GB/day ceiling is approached only by witness-dominated blocks.
-          But the limits matter because they define the maximum stress the network can sustain, and an
+          The ceiling rows are the absolute serialized maximum, 8 MB per block × 1,440 blocks per day, a
+          worst case for a young network.<Cite n={5} /> In practice BTQ blocks are far from full during
+          bootstrapping; the realistic rows assume blocks about half full, the standard planning baseline.
+          A full block of ordinary two-input Dilithium payments is itself weight-limited to ~6.1 MB
+          (~8.8 GB/day); the 11.5 GB/day ceiling is approached only by witness-dominated blocks. The
+          limits still matter because they define the maximum stress the network can sustain, and an
           attacker with enough funds could fill blocks toward this level.
         </p>
         <p>
-          The growth rate is manageable with modern hardware (a 4 TB SSD stores roughly a year of
-          full-block data), but it is a meaningful increase over Bitcoin&rsquo;s current ~600 MB per day.
-          This is an inherent cost of quantum resistance: larger signatures mean more data, however you
-          structure the blocks. The design goal is to keep that cost within reach of commodity hardware,
-          not to eliminate it.
+          The growth rate is manageable with modern hardware. Provisioning roughly 1.5 TB covers an
+          archival node&rsquo;s first year (about 8 TB over five years) against a realistic ~1 TB of annual
+          growth; a pruned node, which validates every block but retains only recent blocks plus the UTXO
+          set, needs about 50 GB. That is a meaningful increase over Bitcoin&rsquo;s ~90&ndash;100 GB per
+          year, but it stays within reach of commodity hardware. This is an inherent cost of quantum
+          resistance: larger signatures mean more data, however you structure the blocks. The design goal
+          is to keep that cost manageable, not to eliminate it.
         </p>
       </section>
 
@@ -286,7 +290,7 @@ export default function BlockSizeTradeoffsGuide() {
           Block timing interacts with the emission schedule in ways that are easy to get wrong. BTQ
           adopted 1-minute blocks (10x faster than Bitcoin) to compensate for the reduced per-block
           transaction capacity. Faster blocks mean more total block space per hour, partially offsetting
-          the 15x transaction size increase.<Cite n={1} />
+          the 20x transaction size increase.<Cite n={1} />
         </p>
         <p>
           But Bitcoin&rsquo;s halving schedule is defined in block count, not wall-clock time. With

--- a/src/app/guides/quantum-secure-bitcoin/block-size-tradeoffs/page.tsx
+++ b/src/app/guides/quantum-secure-bitcoin/block-size-tradeoffs/page.tsx
@@ -1,0 +1,310 @@
+import type { Metadata } from 'next';
+import GuideLayout from '../../_components/GuideLayout';
+
+const TABLE_OF_CONTENTS = [
+  { id: 'the-15x-problem', title: 'The 15x Problem' },
+  { id: 'block-capacity', title: 'Block Capacity Impact' },
+  { id: 'witness-discount', title: 'The Witness Discount Question' },
+  { id: 'chain-growth', title: 'Chain Growth and Node Viability' },
+  { id: 'emission-schedule', title: 'Emission Schedule and Block Timing' },
+  { id: 'no-free-lunch', title: 'No Free Lunch' },
+  { id: 'references', title: 'References' },
+];
+
+const DESC =
+  'Dilithium signatures are 34x larger than ECDSA. That cascades through block sizes, ' +
+  'witness economics, emission schedules, and chain growth. A technical analysis of the tradeoffs.';
+
+export const metadata: Metadata = {
+  title: 'The 15x Problem: Why Quantum-Resistant Transactions Need Bigger Blocks',
+  description: DESC,
+  alternates: { canonical: '/guides/quantum-secure-bitcoin/block-size-tradeoffs' },
+  openGraph: {
+    title: 'The 15x Problem',
+    description: 'Why quantum-resistant transactions need bigger blocks, and what that costs.',
+    url: '/guides/quantum-secure-bitcoin/block-size-tradeoffs',
+    type: 'article',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'The 15x Problem',
+    description: 'Why quantum-resistant transactions need bigger blocks.',
+  },
+};
+
+interface Reference {
+  id: string;
+  cite: React.ReactNode;
+}
+
+const REPO = 'https://github.com/btq-ag/btq-core/blob/v0.3.0-testnet';
+
+const REFERENCES: Reference[] = [
+  {
+    id: 'ref-1',
+    cite: (
+      <>
+        BTQ-Core consensus parameters (v0.3.0-testnet): block size, weight, sigops, and witness scale
+        in{' '}
+        <a href={`${REPO}/src/consensus/consensus.h`} target="_blank" rel="noopener noreferrer">
+          consensus.h
+        </a>
+        , script limits in{' '}
+        <a href={`${REPO}/src/script/script.h`} target="_blank" rel="noopener noreferrer">
+          script.h
+        </a>
+        , and the halving interval, block spacing, and 5 BTQ subsidy in{' '}
+        <a href={`${REPO}/src/kernel/chainparams.cpp`} target="_blank" rel="noopener noreferrer">
+          chainparams.cpp
+        </a>
+        .
+      </>
+    ),
+  },
+  {
+    id: 'ref-2',
+    cite: (
+      <>
+        Open Quantum Safe.{' '}
+        <em>Post-quantum signature sizes</em> (ML-DSA 2,420 bytes; FALCON ~666; SPHINCS+ 7,856 to 49,856).{' '}
+        <a href="https://openquantumsafe.org/liboqs/algorithms/" target="_blank" rel="noopener noreferrer">
+          openquantumsafe.org
+        </a>
+      </>
+    ),
+  },
+  {
+    id: 'ref-3',
+    cite: (
+      <>
+        Lombrozo, Lau &amp; Wuille.{' '}
+        <em>BIP 141: Segregated Witness</em> (the weight formula and witness discount).{' '}
+        <a href="https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki" target="_blank" rel="noopener noreferrer">
+          bitcoin/bips/bip-0141
+        </a>
+      </>
+    ),
+  },
+  {
+    id: 'ref-4',
+    cite: (
+      <>
+        Beast, Heilman &amp; Foster.{' '}
+        <em>BIP-360: Pay-to-Merkle-Root (P2MR)</em>, originally drafted as P2QRH.{' '}
+        <a href="https://bip360.org/" target="_blank" rel="noopener noreferrer">
+          bip360.org
+        </a>
+      </>
+    ),
+  },
+];
+
+function Cite({ n }: { n: number }) {
+  return (
+    <sup className="cite">
+      <a href={`#ref-${n}`}>{n}</a>
+    </sup>
+  );
+}
+
+const CHAIN_GROWTH = [
+  { metric: 'Full-block chain growth / 10 min', btc: '~4 MB', btq: '~80 MB' },
+  { metric: 'Chain growth / day (full blocks)', btc: '~576 MB', btq: '~11.5 GB' },
+  { metric: 'UTXO set growth / 10 min (full blocks)', btc: '~1 MB', btq: '~5.3 MB' },
+];
+
+export default function BlockSizeTradeoffsGuide() {
+  return (
+    <GuideLayout
+      title="The 15x Problem"
+      description="Why quantum-resistant transactions need bigger blocks, and how every parameter change cascades through emission schedules, witness economics, chain growth, and node viability."
+      tableOfContents={TABLE_OF_CONTENTS}
+    >
+      <section id="the-15x-problem">
+        <h2>The 15x Problem</h2>
+        <p>
+          A typical Bitcoin transaction with one input and two outputs (a payment and change) is
+          roughly 250 bytes. The same transaction signed with Dilithium2 is approximately 3,824 bytes,
+          about 15 times larger. This single ratio drives nearly every protocol-level change required
+          to build a quantum-resistant Bitcoin.
+        </p>
+        <p>
+          The size increase comes from the witness data. A Dilithium witness stack contains a 2,421-byte
+          signature (2,420 bytes plus one byte for the sighash type) and a 1,312-byte public key. Compare
+          that to ECDSA&rsquo;s ~72-byte signature and 33-byte compressed public key. The transaction
+          header, input outpoints, and output scripts stay roughly the same size. The authentication data
+          is what explodes.
+        </p>
+        <p>
+          This is not a flaw in Dilithium. It is the cost of quantum resistance. Every post-quantum
+          signature scheme produces larger signatures than ECDSA: FALCON signatures are ~666 bytes,
+          ML-DSA (Dilithium) signatures are ~2,420 bytes, and SPHINCS+ signatures range from 7,856 to
+          49,856 bytes.<Cite n={2} /> No known post-quantum scheme matches ECDSA&rsquo;s compactness. The
+          question is not whether transactions get larger, but how to absorb the increase.
+        </p>
+      </section>
+
+      <section id="block-capacity">
+        <h2>Block Capacity Impact</h2>
+        <p>
+          Bitcoin&rsquo;s block weight limit is 4,000,000 weight units (4 MW), which translates to a
+          maximum serialized block size of roughly 4 MB once you account for the SegWit witness discount.
+          With 250-byte ECDSA transactions, that fits approximately 16,000 transactions per block.
+        </p>
+        <p>
+          With 3,824-byte Dilithium transactions, the same 4 MB block fits approximately 1,050
+          transactions, a 15x reduction in throughput at the same block size. To maintain even
+          Bitcoin&rsquo;s current transaction throughput (already considered low), you need larger blocks.
+        </p>
+        <p>
+          The BTQ project raised <code>MAX_BLOCK_SERIALIZED_SIZE</code> to 8 MB and{' '}
+          <code>MAX_BLOCK_WEIGHT</code> to 8,000,000 weight units. Even then, a full block holds only
+          about 2,100 Dilithium transactions, roughly 13% of what Bitcoin processes per block. The sigops
+          limit was doubled to 80,000 to cover the validation cost of the larger signatures.<Cite n={1} />
+        </p>
+        <p>
+          Other protocol limits needed adjustment too: <code>MAX_SCRIPT_ELEMENT_SIZE</code> rose from 520
+          bytes to 15,000 (to fit Dilithium5 signatures plus keys on the stack),{' '}
+          <code>MAX_SCRIPT_SIZE</code> rose to 100,000 bytes (for complex multi-sig scripts), and{' '}
+          <code>MAX_PROTOCOL_MESSAGE_LENGTH</code> rose to 70 MB (to handle P2P block propagation).<Cite n={1} />
+        </p>
+      </section>
+
+      <section id="witness-discount">
+        <h2>The Witness Discount Question</h2>
+        <p>
+          Bitcoin&rsquo;s SegWit upgrade introduced a witness discount: witness data (signatures and
+          public keys) counts at 1/4 weight, while non-witness data (outputs, scripts) counts at full
+          weight.<Cite n={3} /> The economic rationale is sound: witness data is only needed for
+          validation and can be pruned by archival nodes, while output data (the UTXO set) must be kept
+          permanently. The discount rewards transactions that use more prunable witness space relative to
+          permanent UTXO space.
+        </p>
+        <p>
+          For quantum-resistant transactions, where the witness dominates transaction size, the discount
+          matters even more. Without it, Dilithium&rsquo;s 3,733-byte witness costs the same block weight
+          as 3,733 bytes of UTXO data, erasing any economic signal about what is prunable.
+        </p>
+        <p>
+          The BTQ project initially disabled the witness discount (setting weight equal to serialized
+          size) for simplicity, but community analysis quickly surfaced the consequences. Without the
+          discount, full blocks would generate ~75 GB per day of permanent UTXO set growth at the
+          increased block size, a rate that would make running a full node impractical within weeks.
+        </p>
+        <p>
+          The fix was to restore and increase the witness scale factor to 16 (up from Bitcoin&rsquo;s 4),
+          so witness data counts at 1/16 weight.<Cite n={1} /> That stronger discount reflects the reality
+          that in a Dilithium world, an even larger share of each transaction is prunable witness data.
+          The per-input witness overhead (3,733 bytes) at 1/16 weight costs only ~233 weight units,
+          comparable to the ~26 weight units for ECDSA&rsquo;s ~105-byte witness at Bitcoin&rsquo;s 1/4
+          discount.
+        </p>
+      </section>
+
+      <section id="chain-growth">
+        <h2>Chain Growth and Node Viability</h2>
+        <p>
+          Chain growth rate determines who can run a full node, the foundation of Bitcoin&rsquo;s
+          decentralization. The arithmetic is straightforward:
+        </p>
+
+        <div className="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Metric</th>
+                <th>Bitcoin</th>
+                <th>BTQ (8 MB, 1-min)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {CHAIN_GROWTH.map((row) => (
+                <tr key={row.metric}>
+                  <td>{row.metric}</td>
+                  <td>{row.btc}</td>
+                  <td>{row.btq}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <p>
+          These figures assume full blocks, a worst case for a young network. In practice, BTQ blocks are
+          far from full during bootstrapping. But the limits matter because they define the maximum stress
+          the network can sustain, and an attacker with enough funds could fill blocks to this level.
+        </p>
+        <p>
+          The growth rate is manageable with modern hardware (a 4 TB SSD stores roughly a year of
+          full-block data), but it is a meaningful increase over Bitcoin&rsquo;s current ~600 MB per day.
+          This is an inherent cost of quantum resistance: larger signatures mean more data, however you
+          structure the blocks. The design goal is to keep that cost within reach of commodity hardware,
+          not to eliminate it.
+        </p>
+      </section>
+
+      <section id="emission-schedule">
+        <h2>Emission Schedule and Block Timing</h2>
+        <p>
+          Block timing interacts with the emission schedule in ways that are easy to get wrong. BTQ
+          adopted 1-minute blocks (10x faster than Bitcoin) to compensate for the reduced per-block
+          transaction capacity. Faster blocks mean more total block space per hour, partially offsetting
+          the 15x transaction size increase.<Cite n={1} />
+        </p>
+        <p>
+          But Bitcoin&rsquo;s halving schedule is defined in block count, not wall-clock time. With
+          Bitcoin&rsquo;s 210,000-block interval and 10-minute blocks, halvings land every ~4 years. With
+          1-minute blocks and the same interval, halvings would land every ~5 months, burning through the
+          entire 21 million coin supply in under 3 years.
+        </p>
+        <p>
+          The fix is to scale the interval proportionally: 2,100,000 blocks (10x the Bitcoin interval) at
+          1-minute spacing reproduces the same ~4-year halving cadence. The block reward was set to 5 BTQ
+          (against Bitcoin&rsquo;s initial 50 BTC), with the same 21 million total supply cap. The
+          difficulty retarget window was set to 20,160 blocks (2 weeks at 1-minute spacing, matching
+          Bitcoin&rsquo;s 2-week retarget).<Cite n={1} />
+        </p>
+        <p>
+          Getting these parameters right is critical. Errors in the emission schedule affect miner
+          incentives, supply dynamics, and network security. During development, community review caught a
+          mismatch where block timing was set to 10 minutes while the halving interval assumed 1-minute
+          blocks, which would have produced ~40-year halvings. It was corrected before mainnet deployment,
+          a reminder of why public code review matters for consensus-critical parameters.
+        </p>
+      </section>
+
+      <section id="no-free-lunch">
+        <h2>No Free Lunch</h2>
+        <p>
+          The block size analysis points to one constraint: quantum resistance has a storage cost, and no
+          amount of engineering eliminates it. You can redistribute the cost through witness discounts,
+          offset reduced throughput with faster blocks, and manage chain growth through pruning and
+          archival strategies, but the data itself has to exist somewhere.
+        </p>
+        <p>
+          Every proposed answer to Bitcoin&rsquo;s quantum vulnerability faces the same constraint.
+          BIP-360&rsquo;s P2MR addresses (originally drafted as P2QRH) carry the same signature size
+          overhead.<Cite n={4} /> Any post-quantum scheme adopted by Bitcoin Core will require consensus
+          changes to block weight calculations, script limits, and possibly block timing. The question is
+          not whether to pay this cost, but when and how.
+        </p>
+        <p>
+          What projects like BTQ provide is a live dataset for evaluating these tradeoffs. Theoretical
+          chain-growth calculations are easy to dismiss. Numbers from a running chain processing real
+          transactions are harder to ignore, and easier to use as the basis for informed protocol design.
+        </p>
+      </section>
+
+      <section id="references">
+        <h2>References</h2>
+        <ol className="references">
+          {REFERENCES.map((ref) => (
+            <li key={ref.id} id={ref.id}>
+              {ref.cite}
+            </li>
+          ))}
+        </ol>
+      </section>
+    </GuideLayout>
+  );
+}

--- a/src/app/guides/quantum-secure-bitcoin/block-size-tradeoffs/page.tsx
+++ b/src/app/guides/quantum-secure-bitcoin/block-size-tradeoffs/page.tsx
@@ -97,6 +97,34 @@ const REFERENCES: Reference[] = [
       </>
     ),
   },
+  {
+    id: 'ref-5',
+    cite: (
+      <>
+        <em>Note — weight vs. serialized size.</em> BTQ&rsquo;s only consensus limit on block size is
+        weight: <code>CheckBlock</code> enforces{' '}
+        <code>GetBlockWeight() &le; MAX_BLOCK_WEIGHT</code> (8,000,000), while{' '}
+        <code>MAX_BLOCK_SERIALIZED_SIZE</code> (8 MB) bounds only P2P messages and the block-assembly
+        target, not block validity (
+        <a href={`${REPO}/src/consensus/validation.h`} target="_blank" rel="noopener noreferrer">
+          validation.h
+        </a>
+        ,{' '}
+        <a href={`${REPO}/src/consensus/consensus.h`} target="_blank" rel="noopener noreferrer">
+          consensus.h
+        </a>
+        ). Because weight = 15 &times; (non-witness size) + (total size), weight reaches its cap before
+        serialized size does for any transaction that carries non-witness data, so weight &mdash; not the
+        8 MB figure &mdash; is the binding constraint. A weight-full block of ordinary single-input
+        Dilithium payments holds ~1,540 transactions and is ~5.9 MB on disk (~8.5 GB/day); the 8 MB block
+        and ~11.5 GB/day figures are the asymptotic ceiling, approached only by witness-dominated blocks
+        where non-witness data is negligible. The Bitcoin and BTQ columns above are stated as this
+        serialized ceiling and computed the same way, so the comparison is like-for-like. The per-block
+        transaction counts elsewhere in this guide are likewise size-based; the weight-bound counts are
+        somewhat lower.
+      </>
+    ),
+  },
 ];
 
 function Cite({ n }: { n: number }) {
@@ -158,8 +186,10 @@ export default function BlockSizeTradeoffsGuide() {
         </p>
         <p>
           The BTQ project raised <code>MAX_BLOCK_SERIALIZED_SIZE</code> to 8 MB and{' '}
-          <code>MAX_BLOCK_WEIGHT</code> to 8,000,000 weight units. Even then, a full block holds only
-          about 2,100 Dilithium transactions, roughly 13% of what Bitcoin processes per block. The sigops
+          <code>MAX_BLOCK_WEIGHT</code> to 8,000,000 weight units. The binding consensus limit is block
+          weight, not serialized size,<Cite n={5} /> so a weight-full block of ordinary single-input
+          Dilithium transactions holds roughly 1,540 of them. (Dividing the 8 MB size cap by transaction
+          size suggests ~2,100, but a block of that many would exceed the 8 MW weight limit.) The sigops
           limit was doubled to 80,000 to cover the validation cost of the larger signatures.<Cite n={1} />
         </p>
         <p>
@@ -187,17 +217,21 @@ export default function BlockSizeTradeoffsGuide() {
         </p>
         <p>
           The BTQ project initially disabled the witness discount (setting weight equal to serialized
-          size) for simplicity, but community analysis quickly surfaced the consequences. Without the
-          discount, full blocks would generate ~75 GB per day of permanent UTXO set growth at the
-          increased block size, a rate that would make running a full node impractical within weeks.
+          size) for simplicity, but community analysis quickly surfaced the consequence. With output bytes
+          and witness bytes costing the same weight, nothing discourages bloating the permanent,
+          unprunable UTXO set relative to prunable witness data, exactly the economic signal SegWit&rsquo;s
+          discount exists to send. (Disabling the discount does not shrink chain growth, either; if
+          anything it lets blocks carry slightly more serialized data, since the per-byte penalty on
+          non-witness data is removed.)
         </p>
         <p>
           The fix was to restore and increase the witness scale factor to 16 (up from Bitcoin&rsquo;s 4),
           so witness data counts at 1/16 weight.<Cite n={1} /> That stronger discount reflects the reality
           that in a Dilithium world, an even larger share of each transaction is prunable witness data.
-          The per-input witness overhead (3,733 bytes) at 1/16 weight costs only ~233 weight units,
-          comparable to the ~26 weight units for ECDSA&rsquo;s ~105-byte witness at Bitcoin&rsquo;s 1/4
-          discount.
+          The per-input witness overhead (3,733 bytes) at the 1/16 discount contributes ~233 virtual bytes
+          to the block (weight &divide; 16), versus ~26 virtual bytes for ECDSA&rsquo;s ~105-byte witness
+          under Bitcoin&rsquo;s 1/4 discount. The heavier discount narrows the gap from ~36x in raw witness
+          bytes to ~9x in block-weight terms; it softens the cost, but does not erase it.
         </p>
       </section>
 
@@ -230,9 +264,12 @@ export default function BlockSizeTradeoffsGuide() {
         </div>
 
         <p>
-          These figures assume full blocks, a worst case for a young network. In practice, BTQ blocks are
-          far from full during bootstrapping. But the limits matter because they define the maximum stress
-          the network can sustain, and an attacker with enough funds could fill blocks to this level.
+          These figures are the absolute serialized ceiling, 8 MB per block × 1,440 blocks per day, and
+          assume full blocks, a worst case for a young network.<Cite n={5} /> In practice, BTQ blocks are
+          far from full during bootstrapping, and a full block of ordinary Dilithium payments is weight-limited
+          to ~5.9 MB (~8.5 GB/day); the 11.5 GB/day ceiling is approached only by witness-dominated blocks.
+          But the limits matter because they define the maximum stress the network can sustain, and an
+          attacker with enough funds could fill blocks toward this level.
         </p>
         <p>
           The growth rate is manageable with modern hardware (a 4 TB SSD stores roughly a year of

--- a/src/app/guides/quantum-secure-bitcoin/block-size-tradeoffs/page.tsx
+++ b/src/app/guides/quantum-secure-bitcoin/block-size-tradeoffs/page.tsx
@@ -221,9 +221,9 @@ export default function BlockSizeTradeoffsGuide() {
           size) for simplicity, but community analysis quickly surfaced the consequence. With output bytes
           and witness bytes costing the same weight, nothing discourages bloating the permanent,
           unprunable UTXO set relative to prunable witness data, exactly the economic signal SegWit&rsquo;s
-          discount exists to send. (Disabling the discount does not shrink chain growth, either; if
-          anything it lets blocks carry slightly more serialized data, since the per-byte penalty on
-          non-witness data is removed.)
+          discount exists to send. Note: disabling the discount does not shrink chain growth, either; if
+          anything, it lets blocks carry slightly more serialized data since the per-byte penalty on
+          non-witness data is removed.
         </p>
         <p>
           The fix was to restore and increase the witness scale factor to 16 (up from Bitcoin&rsquo;s 4),
@@ -231,8 +231,8 @@ export default function BlockSizeTradeoffsGuide() {
           that in a Dilithium world, an even larger share of each transaction is prunable witness data.
           The per-input witness overhead (3,733 bytes) at the 1/16 discount contributes ~233 virtual bytes
           to the block (weight &divide; 16), versus ~26 virtual bytes for ECDSA&rsquo;s ~105-byte witness
-          under Bitcoin&rsquo;s 1/4 discount. The heavier discount narrows the gap from ~36x in raw witness
-          bytes to ~9x in block-weight terms; it softens the cost, but does not erase it.
+          under Bitcoin&rsquo;s 1/4 discount. In summary, the heavier discount narrows the gap from ~36x in raw witness
+          bytes to ~9x in block-weight terms. This softens the cost, but does not erase it.
         </p>
       </section>
 
@@ -240,7 +240,7 @@ export default function BlockSizeTradeoffsGuide() {
         <h2>Chain Growth and Node Viability</h2>
         <p>
           Chain growth rate determines who can run a full node, the foundation of Bitcoin&rsquo;s
-          decentralization. The arithmetic is straightforward:
+          decentralization. The arithmetic is straightforward as outlined below:
         </p>
 
         <div className="table-wrap">
@@ -266,7 +266,7 @@ export default function BlockSizeTradeoffsGuide() {
 
         <p>
           The ceiling rows are the absolute serialized maximum, 8 MB per block × 1,440 blocks per day, a
-          worst case for a young network.<Cite n={5} /> In practice BTQ blocks are far from full during
+          worst case scenario for an early network.<Cite n={5} /> In practice BTQ blocks are far from full during
           bootstrapping; the realistic rows assume blocks about half full, the standard planning baseline.
           A full block of ordinary two-input Dilithium payments is itself weight-limited to ~6.1 MB
           (~8.8 GB/day); the 11.5 GB/day ceiling is approached only by witness-dominated blocks. The
@@ -278,7 +278,7 @@ export default function BlockSizeTradeoffsGuide() {
           archival node&rsquo;s first year (about 8 TB over five years) against a realistic ~1 TB of annual
           growth; a pruned node, which validates every block but retains only recent blocks plus the UTXO
           set, needs about 50 GB. That is a meaningful increase over Bitcoin&rsquo;s ~90&ndash;100 GB per
-          year, but it stays within reach of commodity hardware. This is an inherent cost of quantum
+          year, but it stays within reach of today's commodity hardware. This is an inherent cost of quantum
           resistance: larger signatures mean more data, however you structure the blocks. The design goal
           is to keep that cost manageable, not to eliminate it.
         </p>
@@ -287,15 +287,15 @@ export default function BlockSizeTradeoffsGuide() {
       <section id="emission-schedule">
         <h2>Emission Schedule and Block Timing</h2>
         <p>
-          Block timing interacts with the emission schedule in ways that are easy to get wrong. BTQ
+          Block timing interacts with the emission schedule in ways that are easily misunderstood. BTQ
           adopted 1-minute blocks (10x faster than Bitcoin) to compensate for the reduced per-block
           transaction capacity. Faster blocks mean more total block space per hour, partially offsetting
           the 20x transaction size increase.<Cite n={1} />
         </p>
         <p>
-          But Bitcoin&rsquo;s halving schedule is defined in block count, not wall-clock time. With
+          But Bitcoin&rsquo;s halving schedule is defined in block count, not clock time. With
           Bitcoin&rsquo;s 210,000-block interval and 10-minute blocks, halvings land every ~4 years. With
-          1-minute blocks and the same interval, halvings would land every ~5 months, burning through the
+          1-minute blocks and all else constant, halvings would land every ~5 months, burning through the
           entire 21 million coin supply in under 3 years.
         </p>
         <p>
@@ -309,8 +309,8 @@ export default function BlockSizeTradeoffsGuide() {
           Getting these parameters right is critical. Errors in the emission schedule affect miner
           incentives, supply dynamics, and network security. During development, community review caught a
           mismatch where block timing was set to 10 minutes while the halving interval assumed 1-minute
-          blocks, which would have produced ~40-year halvings. It was corrected before mainnet deployment,
-          a reminder of why public code review matters for consensus-critical parameters.
+          blocks, which would have produced ~40-year halvings. It was corrected during testnet deployment,
+          a reminder of why live testing and public code review matters for consensus-critical parameters.
         </p>
       </section>
 
@@ -330,8 +330,8 @@ export default function BlockSizeTradeoffsGuide() {
           not whether to pay this cost, but when and how.
         </p>
         <p>
-          What projects like BTQ provide is a live dataset for evaluating these tradeoffs. Theoretical
-          chain-growth calculations are easy to dismiss. Numbers from a running chain processing real
+          Projects such as Bitcoin Quantum provide practical datasets for evaluating these tradeoffs. Theoretical
+          chain-growth calculations are easy to dismiss. Metrics gathered from a live hardened network processing real
           transactions are harder to ignore, and easier to use as the basis for informed protocol design.
         </p>
       </section>

--- a/src/app/guides/quantum-secure-bitcoin/signature-migration/page.tsx
+++ b/src/app/guides/quantum-secure-bitcoin/signature-migration/page.tsx
@@ -139,7 +139,7 @@ const SIZE_ROWS = [
   { component: 'Signature', ecdsa: '~72 bytes', dilithium: '2,420 bytes', ratio: '34x' },
   { component: 'Private key', ecdsa: '32 bytes', dilithium: '2,560 bytes', ratio: '80x' },
   { component: 'Per-input witness', ecdsa: '~105 bytes', dilithium: '~3,733 bytes', ratio: '36x' },
-  { component: '1-input transaction', ecdsa: '~250 bytes', dilithium: '~3,824 bytes', ratio: '15x' },
+  { component: '2-in/2-out transaction', ecdsa: '~372 bytes', dilithium: '~7,636 bytes', ratio: '20x' },
 ];
 
 const OPCODES = [
@@ -274,7 +274,7 @@ export default function SignatureMigrationGuide() {
           Every one of these size increases propagates through the system: block sizes must grow to
           maintain throughput, network message limits must increase for block propagation, script
           size limits must accommodate larger stack elements, and wallet storage expands significantly.
-          The 15x transaction size increase is the single most important number in quantum-resistant
+          The 20x transaction size increase is the single most important number in quantum-resistant
           Bitcoin design. Every engineering decision downstream flows from it.
         </p>
       </section>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -36,6 +36,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
+      url: `${baseUrl}/guides/quantum-secure-bitcoin/block-size-tradeoffs`,
+      lastModified: currentDate,
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/faq`,
       lastModified: currentDate,
       changeFrequency: 'monthly',


### PR DESCRIPTION
Adds **"The 20x Problem"** (guide 2 of the quantum-secure-bitcoin series): why quantum-resistant transactions need bigger blocks, and how every parameter change cascades through emission schedules, witness economics, chain growth, and node viability.

## What's in this PR
- `block-size-tradeoffs/page.tsx` — the new guide.
- `block-size-tradeoffs/opengraph-image.tsx` — its dynamic OG image.
- `guides/_data/guides.ts` — lists the guide in the hub so it's discoverable.
- `sitemap.ts` — adds the route to the sitemap.
- `signature-migration/page.tsx` — **2-line consistency edit** to the existing (already-live) guide: its size table row and headline ratio, so the whole series uses the same canonical number. Edited here to avoid a cross-guide mismatch when this guide ships.
- `faq/page.tsx` — **consistency edit** to the "How is BTQ different from Bitcoin?" answer: corrected the block-size framing (`1 MB → 8 MB`, an 8× framing mixing Bitcoin's pre-SegWit base with BTQ's cap) to the guides' like-for-like **~4 MB → 8 MB (2×)**, and softened "the halving schedule stays exactly as Bitcoin defined it" (the parameters were rescaled to preserve the 21M cap + ~4-year cadence; block time also changed).
- `.gitignore` — ignores `/docs/reference/` (local-only dev-team storage-model PDFs + reconciliation notes used to validate this guide).

No CSS changes (uses the shared `.table-wrap` styles already in `main`).

## Framing: reconciled to the dev-team storage model
The guide's figures were cross-checked against the BTQ Core dev team's full-node storage model (commit `877c8532`). Their canonical reference transaction is **2-in/2-out (≈372 B → ≈7,636 B, ~20×)**, so this PR adopts that as the headline framing:

- **Retitled "The 15x Problem" → "The 20x Problem"** — slug `block-size-tradeoffs` unchanged, so no redirect.
- **Per-block counts recomputed** for the 372 B / 7,636 B pair; a weight-full BTQ block holds ≈800 two-input Dilithium txs; per-input witness ≈3,733 B.
- **Chain-growth table rebuilt on the model's figures** — day/year full-block ceilings (≈11.5 GB/day, ≈4.2 TB/yr), a realistic ~50%-full row (~1 TB/yr vs Bitcoin ~90–100 GB/yr), and UTXO normal-traffic growth (~3 GB/yr). This **resolves the prior unreproducible "~5.3 MB/10-min UTXO row"** follow-up.
- **Added pruned-node (50 GB) and archival provisioning (1.5 TB yr-1 / 8 TB 5-yr)** guidance; corrected "Bitcoin ~600 MB/day" (that's full-block capacity, not observed growth).
- **FAQ aligned** to the same like-for-like framing (see file list).
- The 34× ratio (signature-level) is retained where it appears — it matches the model; 20× is the transaction-level ratio.

Earlier commits in this PR established the weight-vs-serialized-size binding-limit footnote and corrected the witness-discount framing; those remain.

## Test plan
- `npm run build` passes (static pages; new route + its OG image).
- `npm run lint` clean.
- Guide renders on `/guides`; tables scroll horizontally on mobile via `.table-wrap`.

## Adopted the dev team's storage-model framing as canonical

Cross-checked this guide against the BTQ Core dev team's full-node storage model (built against BTQ Core commit \`877c8532\`). The model's canonical reference transaction is **2-in/2-out** (≈372 B → ≈7,636 B, **~20×**; the model states "a typical BTQ transaction is about 20× the size of its Bitcoin equivalent"). This guide had used a 1-input example (~15×), so the headline ratios differed from the team's source of truth.

Per the dev team's framing, this guide now adopts the 2-in/2-out / ~20× canonical (f910dde):

- **Retitled "The 15x Problem" → "The 20x Problem"** across the page, OG image, and guides hub. **Slug is unchanged** (\`block-size-tradeoffs\`), so no redirect is needed.
- **Per-block counts recomputed** for the 372 B / 7,636 B pair; per-input witness called out (~3,733 B); a weight-full BTQ block holds ~800 two-input txs.
- **Chain-growth table rebuilt on the model's figures** — day/year full-block ceilings, a realistic ~50%-full row (~1 TB/yr vs Bitcoin ~90–100 GB/yr), and UTXO normal-traffic growth (~3 GB/yr), replacing a prior UTXO row whose basis didn't reconcile with the model.
- **Added pruned-node (50 GB) and archival provisioning (1.5 TB yr-1 / 8 TB 5-yr)** guidance; corrected "Bitcoin ~600 MB/day" (that's full-block capacity, not observed growth).
- **Series consistency:** \`signature-migration\` updated to the same 2-in/2-out / 20× canonical.

The 34× ratio (signature-level) is retained where it appears — that's the signature size ratio and matches the model; 20× is the transaction-level ratio. Build passes.