### PR TITLE
feat(guides): number guide cards and widen guide subheader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ next-env.d.ts
 # internal content/voice/strategy + Typefully integration — local-only,
 # not for the public repo
 /docs/content/
+.gstack/
+.playwright-mcp/

--- a/src/app/guides/_components/GuideLayout.tsx
+++ b/src/app/guides/_components/GuideLayout.tsx
@@ -79,7 +79,7 @@ export default function GuideLayout({
         <V2Nav />
 
         <main>
-          <article className="section">
+          <article className="section guide-page">
             <div className="wrap">
               <nav className="guide-breadcrumb" aria-label="Breadcrumb">
                 <Link href="/">Home</Link>

--- a/src/app/guides/page.tsx
+++ b/src/app/guides/page.tsx
@@ -82,14 +82,17 @@ export default function GuidesHub() {
                 <h1>Quantum-Secure Bitcoin</h1>
                 <p>{DESC}</p>
               </header>
-              <div className="guide" style={{ maxWidth: '72ch' }}>
-                {RELEASED_GUIDES.map((g) => (
-                  <Link key={g.slug} href={g.href} className="data-row" style={{ display: 'block', textDecoration: 'none' }}>
-                    <div className="row-head">
-                      <span className="label">{g.title}</span>
-                      <span className="ratio">&rarr;</span>
+              <div className="guide guide-hub">
+                {RELEASED_GUIDES.map((g, i) => (
+                  <Link key={g.slug} href={g.href} className="data-row">
+                    <span className="guide-num" aria-hidden="true">{i + 1}</span>
+                    <div className="guide-card-body">
+                      <div className="row-head">
+                        <span className="label">{g.title}</span>
+                        <span className="ratio">&rarr;</span>
+                      </div>
+                      <p className="detail">{g.blurb}</p>
                     </div>
-                    <p className="detail">{g.blurb}</p>
                   </Link>
                 ))}
               </div>

--- a/src/components/v2/v2.css
+++ b/src/components/v2/v2.css
@@ -1254,6 +1254,37 @@
 .bqv2 .guide-back a { color: var(--ink-3); text-decoration: none; font-size: 14px; }
 .bqv2 .guide-back a:hover { color: var(--accent-ink); }
 
+/* individual guide pages: the subheader widens beyond the 72ch prose measure.
+   On desktop it stops at the right edge of the two-column article body — the
+   TOC (220px) + column gap (56px) + prose column (72ch ≈ 685px at the 17px body
+   font) = 961px — rather than filling the whole wrap. When the viewport is too
+   narrow for the prose to reach 72ch, the subheader is bounded by the same
+   available width and tracks the prose edge automatically. Below the two-column
+   breakpoint the TOC stacks full-width, so the subheader fills the column too. */
+.bqv2 .guide-page .guide-header p { max-width: none; }
+@media (min-width: 1024px) {
+  .bqv2 .guide-page .guide-header p { max-width: 961px; }
+}
+
+/* numbered guide cards (qdayanon-style: number badge + body) */
+.bqv2 .guide-hub .data-row { display: flex; align-items: flex-start; gap: 16px; }
+.bqv2 .guide-num {
+  flex-shrink: 0;
+  width: 38px;
+  height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1;
+  color: #fff;
+  background: var(--accent-ink);
+  border-radius: 8px;
+}
+.bqv2 .guide-card-body { flex: 1; min-width: 0; }
+
 /* clickable hub cards (a data-row rendered as a link) get hover feedback;
    static data rows inside articles (a plain div) are unaffected */
 .bqv2 .guide a.data-row { transition: border-color .15s ease, background .15s ease; }

--- a/src/components/v2/v2.css
+++ b/src/components/v2/v2.css
@@ -1287,7 +1287,7 @@
 
 /* clickable hub cards (a data-row rendered as a link) get hover feedback;
    static data rows inside articles (a plain div) are unaffected */
-.bqv2 .guide a.data-row { transition: border-color .15s ease, background .15s ease; }
+.bqv2 .guide a.data-row { text-decoration: none; transition: border-color .15s ease, background .15s ease; }
 .bqv2 .guide a.data-row:hover { border-color: var(--accent); background: var(--bg-2); }
 
 /* inline citation markers + references list */


### PR DESCRIPTION
## What

Two guide-page refinements requested by the user:

1. **Number the guide cards** on the `/guides` index, matching the qdayanon-content-engine pattern: a numbered badge box to the left of each card's title/blurb.
2. **Widen the subheader** on individual guide pages (e.g. `/guides/quantum-secure-bitcoin/block-size-tradeoffs`) so it spans the full article-body width instead of the 72ch reading measure.

## Details

- `src/app/guides/page.tsx` — each card now renders a `.guide-num` badge (`1`, `2`, …) from its position in `RELEASED_GUIDES`, with a flex `.guide-card-body` wrapper. Index column widths are unchanged from the original.
- `src/components/v2/v2.css` — adds `.guide-num` badge styling (uses `--accent-ink`, works in light/dark) and the `.guide-page` subheader widening. On desktop the subheader caps at `961px` = TOC (220) + gap (56) + prose column (72ch ≈ 685px), so its right edge aligns exactly with the prose column. Below the two-column breakpoint the TOC stacks full-width and the subheader fills the column.
- `src/app/guides/_components/GuideLayout.tsx` — adds a `guide-page` class so the widening is scoped to individual guides only (article prose keeps its 72ch measure).
- `.gitignore` — ignore local tooling dirs (`.gstack/`, `.playwright-mcp/`).

## Verification

Measured live with Playwright at 1440px: subheader right edge (1106px) now aligns exactly with the prose column right edge (1106px). Confirmed visually via screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)